### PR TITLE
feat: Implement Go CLI backend order controller with CI scripts and t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Build artifacts
+order-controller
+# IDE configs
+.idea/
+# Go test/coverage artifacts
+coverage.out

--- a/README.md
+++ b/README.md
@@ -62,3 +62,12 @@ You must implement **either** frontend or backend components as described below:
 - Testing, testing and testing. Make sure the prototype is functioning and meeting all the requirements.
 - Treat this assignment as a vibe coding, don't over engineer it. Try to scope your working hour within 30 min. However, ensure you read and understand what your code doing.
 - Complete the implementation as clean as possible, clean code is a strong plus point, do not bring in all the fancy tech stuff.
+
+### Backend Quick Start (Go CLI)
+- Run tests: `./scripts/test.sh`
+- Build CLI: `./scripts/build.sh`
+- Execute scripted run and generate output: `./scripts/run.sh`
+- Inspect run output: `scripts/result.txt`
+
+### Documentation
+- Backend implementation details and design trade-offs: `docs/backend-solution.md`

--- a/cmd/order-controller/main.go
+++ b/cmd/order-controller/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"se-take-home-assignment/internal/app"
+	"se-take-home-assignment/internal/domain"
+)
+
+func main() {
+	// We print lifecycle logs to stdout because CI captures stdout into result.txt.
+	controller := domain.NewController(10*time.Second, func(format string, args ...any) {
+		fmt.Fprintf(os.Stdout, format+"\n", args...)
+	})
+	fmt.Fprintf(os.Stdout, "[%s] System initialized with 0 bots\n", time.Now().Format("15:04:05"))
+	cli := app.NewCLI(os.Stdin, os.Stdout, controller)
+
+	if err := cli.Run(); err != nil && !errors.Is(err, io.EOF) {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/backend-solution.md
+++ b/docs/backend-solution.md
@@ -1,0 +1,184 @@
+# Backend Solution (Go CLI)
+
+This document explains the final backend implementation, how to run it, and the engineering trade-offs made for this assignment.
+
+## 1. Implementation Approach (Step-by-Step)
+
+### Step 1: Scope and Constraints
+
+- Use Go to build a CLI backend.
+- Keep all state in memory (no persistence required).
+- Make execution deterministic for GitHub Actions.
+
+### Step 2: Domain Modeling
+
+- `Order`
+  - `ID`: user-facing order number (increasing, starts from `1001`).
+  - `Sequence`: internal insertion order for stable re-queue behavior.
+  - `Type`: `VIP` or `NORMAL`.
+  - `Status`: `PENDING`, `PROCESSING`, `COMPLETE`.
+- `Bot`
+  - `ID`: increasing bot id.
+  - `State`: `IDLE` or `BUSY`.
+  - `CurrentOrder`: currently processing order (if any).
+  - internal cancel function.
+
+### Step 3: Business Controller
+
+`Controller` is the in-memory source of truth:
+
+- Queues:
+  - `pendingVIP`
+  - `pendingNormal`
+  - `completed`
+  - `bots`
+- Synchronization:
+  - protect all mutable state with `sync.Mutex`.
+- Main public operations:
+  - create normal order
+  - create VIP order
+  - add bot
+  - remove latest bot
+  - return snapshot
+  - return final metrics summary
+
+### Step 4: Scheduling and Processing
+
+- Dispatch rule:
+  - always pick VIP queue first, then normal queue.
+  - keep FIFO inside each queue.
+- Processing rule:
+  - one bot handles one order at a time.
+  - processing takes 10 seconds in runtime.
+  - on completion, order moves to `COMPLETE`.
+
+### Step 5: Cancel and Re-queue Rule
+
+When removing the latest bot:
+
+- if idle: remove immediately.
+- if busy:
+  - cancel current processing.
+  - move current order back to pending.
+  - restore queue order by `Sequence`, while preserving VIP priority.
+
+### Step 6: CLI and Reporting
+
+- Interactive mode prints banner and prompt.
+- Non-interactive mode (scripted CI run) suppresses prompt noise.
+- Supports `summary` command for final report output.
+
+### Step 7: Script Automation
+
+- `scripts/test.sh`: run tests with race detector.
+- `scripts/build.sh`: build binary.
+- `scripts/run.sh`: run deterministic scenario and write `scripts/result.txt`.
+- `run.sh` writes the report title line, then appends CLI output.
+
+### Step 8: Tests
+
+Tests cover:
+
+- VIP/Normal priority and FIFO behavior.
+- order id increase behavior.
+- processing completion flow.
+- bot removal edge cases (busy/idle/empty/LIFO).
+- concurrent stress scenario.
+- race-safe behavior (`-race`).
+
+## 2. How To Run
+
+From repository root:
+
+```bash
+./scripts/test.sh
+./scripts/build.sh
+./scripts/run.sh
+```
+
+Check generated output:
+
+```bash
+cat scripts/result.txt
+```
+
+## 3. Design Decisions and Trade-offs
+
+- **In-memory only**: assignment does not require persistence.
+- **String enums**: clearer logs and better interview readability.
+- **Mutex-based state management**: simple and robust for this scale.
+- **Deterministic scripted run**: stable CI output and easier debugging.
+- **Non-interactive output cleanup**: removes prompt noise from `result.txt`.
+- **Timer-based processing (`time.NewTimer`)**: better control on cancellation path than `time.After`.
+- **Minimal dependencies**: standard library only.
+
+## 4. CLI Commands
+
+Supported commands:
+
+- `new normal`
+- `new vip`
+- `add bot`
+- `remove bot`
+- `status`
+- `summary`
+- `sleep N`
+- `help`
+- `exit`
+
+Example command flow (used by `scripts/run.sh`):
+
+```text
+new normal
+new vip
+new normal
+add bot
+sleep 1
+add bot
+sleep 11
+new vip
+sleep 11
+remove bot
+sleep 1
+summary
+exit
+```
+
+Example output lines:
+
+```text
+McDonald's Order Management System - Simulation Results
+
+[20:22:59] System initialized with 0 bots
+[20:22:59] Created Normal Order #1001 - Status: PENDING
+[20:22:59] Created VIP Order #1002 - Status: PENDING
+[20:22:59] Created Normal Order #1003 - Status: PENDING
+[20:22:59] Bot #1 created - Status: ACTIVE
+[20:22:59] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
+[20:23:00] Bot #2 created - Status: ACTIVE
+[20:23:00] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
+[20:23:09] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
+[20:23:10] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
+...
+Final Status:
+- Total Orders Processed: 4 (2 VIP, 2 Normal)
+- Orders Completed: 4
+- Active Bots: 1
+- Pending Orders: 0
+```
+
+## 5. Project Structure (Backend Part)
+
+```text
+cmd/order-controller/main.go
+internal/app/cli.go
+internal/domain/order.go
+internal/domain/bot.go
+internal/domain/controller.go
+internal/domain/controller_test.go
+scripts/test.sh
+scripts/build.sh
+scripts/run.sh
+scripts/result.txt
+docs/backend-solution.md
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module se-take-home-assignment
+
+go 1.23.9

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -1,0 +1,130 @@
+package app
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"se-take-home-assignment/internal/domain"
+)
+
+// CLI provides a tiny interactive shell for the order controller.
+type CLI struct {
+	in          io.Reader
+	out         io.Writer
+	controller  *domain.Controller
+	interactive bool
+}
+
+// NewCLI creates a CLI runtime with injected I/O for testability.
+func NewCLI(in io.Reader, out io.Writer, controller *domain.Controller) *CLI {
+	interactive := false
+	if f, ok := in.(*os.File); ok {
+		if info, err := f.Stat(); err == nil && (info.Mode()&os.ModeCharDevice) != 0 {
+			interactive = true
+		}
+	}
+	return &CLI{
+		in:          in,
+		out:         out,
+		controller:  controller,
+		interactive: interactive,
+	}
+}
+
+// Run starts the command loop until "exit" or EOF.
+func (c *CLI) Run() error {
+	scanner := bufio.NewScanner(c.in)
+	if c.interactive {
+		fmt.Fprintln(c.out, "Order Controller CLI")
+		fmt.Fprintln(c.out, "Type \"help\" for available commands.")
+	}
+	for {
+		if c.interactive {
+			fmt.Fprint(c.out, "> ")
+		}
+		if !scanner.Scan() {
+			return nil
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if err := c.handleLine(line); err != nil {
+			return err
+		}
+	}
+}
+
+func (c *CLI) handleLine(line string) error {
+	parts := strings.Fields(strings.ToLower(line))
+	if len(parts) == 0 {
+		return nil
+	}
+
+	switch {
+	case len(parts) == 1 && parts[0] == "help":
+		c.printHelp()
+	case len(parts) == 1 && parts[0] == "status":
+		c.printStatus()
+	case len(parts) == 1 && parts[0] == "summary":
+		c.printSummary()
+	case len(parts) == 2 && parts[0] == "add" && parts[1] == "bot":
+		c.controller.AddBot()
+	case len(parts) == 2 && parts[0] == "remove" && parts[1] == "bot":
+		if err := c.controller.RemoveLatestBot(); err != nil {
+			fmt.Fprintf(c.out, "error: %v\n", err)
+		}
+	case len(parts) == 2 && parts[0] == "new" && parts[1] == "normal":
+		c.controller.NewNormalOrder()
+	case len(parts) == 2 && parts[0] == "new" && parts[1] == "vip":
+		c.controller.NewVIPOrder()
+	case len(parts) == 2 && parts[0] == "sleep":
+		seconds, err := strconv.Atoi(parts[1])
+		if err != nil || seconds < 0 {
+			fmt.Fprintln(c.out, "error: sleep expects non-negative integer seconds")
+			return nil
+		}
+		time.Sleep(time.Duration(seconds) * time.Second)
+	case len(parts) == 1 && parts[0] == "exit":
+		return io.EOF
+	default:
+		fmt.Fprintf(c.out, "unknown command: %s\n", line)
+	}
+	return nil
+}
+
+func (c *CLI) printHelp() {
+	fmt.Fprintln(c.out, "Commands:")
+	fmt.Fprintln(c.out, "  new normal   - create a normal order")
+	fmt.Fprintln(c.out, "  new vip      - create a VIP order")
+	fmt.Fprintln(c.out, "  add bot      - add one cooking bot")
+	fmt.Fprintln(c.out, "  remove bot   - remove latest cooking bot")
+	fmt.Fprintln(c.out, "  status       - print current system snapshot")
+	fmt.Fprintln(c.out, "  sleep N      - wait N seconds (for scripted runs)")
+	fmt.Fprintln(c.out, "  summary      - print final summary report")
+	fmt.Fprintln(c.out, "  help         - print this message")
+	fmt.Fprintln(c.out, "  exit         - quit")
+}
+
+func (c *CLI) printStatus() {
+	snapshot := c.controller.Snapshot()
+	fmt.Fprintf(c.out, "[%s] bots: %v\n", time.Now().Format("15:04:05"), snapshot.BotSummaries)
+	fmt.Fprintf(c.out, "[%s] pending_vip: %v\n", time.Now().Format("15:04:05"), snapshot.PendingVIPIDs)
+	fmt.Fprintf(c.out, "[%s] pending_normal: %v\n", time.Now().Format("15:04:05"), snapshot.PendingNormalIDs)
+	fmt.Fprintf(c.out, "[%s] complete: %v\n", time.Now().Format("15:04:05"), snapshot.CompletedOrderIDs)
+}
+
+func (c *CLI) printSummary() {
+	m := c.controller.Metrics()
+	fmt.Fprintln(c.out, "")
+	fmt.Fprintln(c.out, "Final Status:")
+	fmt.Fprintf(c.out, "- Total Orders Processed: %d (%d VIP, %d Normal)\n", m.TotalOrders, m.TotalVIP, m.TotalNormal)
+	fmt.Fprintf(c.out, "- Orders Completed: %d\n", m.Completed)
+	fmt.Fprintf(c.out, "- Active Bots: %d\n", m.ActiveBots)
+	fmt.Fprintf(c.out, "- Pending Orders: %d\n", m.PendingOrders)
+}

--- a/internal/domain/bot.go
+++ b/internal/domain/bot.go
@@ -1,0 +1,21 @@
+package domain
+
+import "context"
+
+// BotState declares whether a bot is available or working.
+type BotState string
+
+const (
+	// BotStateIdle means the bot is waiting for work.
+	BotStateIdle BotState = "IDLE"
+	// BotStateBusy means the bot is processing one order.
+	BotStateBusy BotState = "BUSY"
+)
+
+// Bot tracks one worker's runtime state.
+type Bot struct {
+	ID           int
+	State        BotState
+	CurrentOrder *Order
+	cancel       context.CancelFunc
+}

--- a/internal/domain/controller.go
+++ b/internal/domain/controller.go
@@ -1,0 +1,325 @@
+package domain
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Snapshot is a read-only view used by CLI and tests.
+type Snapshot struct {
+	BotSummaries      []string
+	PendingVIPIDs     []int
+	PendingNormalIDs  []int
+	CompletedOrderIDs []int
+}
+
+// Metrics is a compact summary used for final reporting.
+type Metrics struct {
+	TotalOrders   int
+	TotalVIP      int
+	TotalNormal   int
+	Completed     int
+	ActiveBots    int
+	PendingOrders int
+}
+
+// Controller contains all in-memory state and domain rules.
+type Controller struct {
+	mu sync.Mutex
+
+	nextOrderID int
+	nextSeq     int
+	nextBotID   int
+
+	pendingVIP    []*Order
+	pendingNormal []*Order
+	completed     []*Order
+	bots          []*Bot
+	completedVIP  int
+	completedNorm int
+
+	processingDuration time.Duration
+	logf               func(format string, args ...any)
+}
+
+// NewController creates a controller with configurable processing duration.
+func NewController(processingDuration time.Duration, logf func(format string, args ...any)) *Controller {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &Controller{
+		nextOrderID:        1000,
+		processingDuration: processingDuration,
+		logf:               logf,
+	}
+}
+
+// NewNormalOrder inserts a normal order and triggers scheduling.
+func (c *Controller) NewNormalOrder() Order {
+	return c.createOrder(OrderTypeNormal)
+}
+
+// NewVIPOrder inserts a VIP order and triggers scheduling.
+func (c *Controller) NewVIPOrder() Order {
+	return c.createOrder(OrderTypeVIP)
+}
+
+func (c *Controller) createOrder(orderType OrderType) Order {
+	c.mu.Lock()
+	c.nextOrderID++
+	c.nextSeq++
+
+	order := &Order{
+		ID:        c.nextOrderID,
+		Sequence:  c.nextSeq,
+		Type:      orderType,
+		Status:    OrderStatusPending,
+		CreatedAt: time.Now(),
+	}
+	if orderType == OrderTypeVIP {
+		c.pendingVIP = append(c.pendingVIP, order)
+	} else {
+		c.pendingNormal = append(c.pendingNormal, order)
+	}
+	c.logf("[%s] Created %s Order #%d - Status: %s", hhmmss(), displayOrderType(order.Type), order.ID, order.Status)
+	orderCopy := *order
+	c.mu.Unlock()
+
+	c.dispatch()
+	return orderCopy
+}
+
+// AddBot registers a bot and lets it pull pending work immediately.
+func (c *Controller) AddBot() Bot {
+	c.mu.Lock()
+	c.nextBotID++
+	bot := &Bot{
+		ID:    c.nextBotID,
+		State: BotStateIdle,
+	}
+	c.bots = append(c.bots, bot)
+	c.logf("[%s] Bot #%d created - Status: ACTIVE", hhmmss(), bot.ID)
+	botCopy := *bot
+	c.mu.Unlock()
+
+	c.dispatch()
+	return botCopy
+}
+
+// RemoveLatestBot removes the most recently added bot.
+func (c *Controller) RemoveLatestBot() error {
+	c.mu.Lock()
+	if len(c.bots) == 0 {
+		c.mu.Unlock()
+		return fmt.Errorf("no bot to remove")
+	}
+
+	latestIdx := len(c.bots) - 1
+	bot := c.bots[latestIdx]
+	c.bots = c.bots[:latestIdx]
+
+	// If the bot is in progress, cancel and re-queue the current order.
+	if bot.cancel != nil {
+		bot.cancel()
+		bot.cancel = nil
+	}
+	if bot.CurrentOrder != nil && bot.CurrentOrder.Status == OrderStatusProcessing {
+		bot.CurrentOrder.Status = OrderStatusPending
+		c.enqueuePending(bot.CurrentOrder)
+		c.logf("[%s] Bot #%d destroyed while processing Order #%d - Re-queued to PENDING", hhmmss(), bot.ID, bot.CurrentOrder.ID)
+	} else {
+		c.logf("[%s] Bot #%d destroyed while IDLE", hhmmss(), bot.ID)
+	}
+	c.mu.Unlock()
+
+	c.dispatch()
+	return nil
+}
+
+func (c *Controller) enqueuePending(order *Order) {
+	if order.Type == OrderTypeVIP {
+		c.pendingVIP = append(c.pendingVIP, order)
+		sort.SliceStable(c.pendingVIP, func(i, j int) bool {
+			return c.pendingVIP[i].Sequence < c.pendingVIP[j].Sequence
+		})
+		return
+	}
+	c.pendingNormal = append(c.pendingNormal, order)
+	sort.SliceStable(c.pendingNormal, func(i, j int) bool {
+		return c.pendingNormal[i].Sequence < c.pendingNormal[j].Sequence
+	})
+}
+
+// Snapshot returns a consistent state view.
+func (c *Controller) Snapshot() Snapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	s := Snapshot{
+		BotSummaries:      make([]string, 0, len(c.bots)),
+		PendingVIPIDs:     make([]int, 0, len(c.pendingVIP)),
+		PendingNormalIDs:  make([]int, 0, len(c.pendingNormal)),
+		CompletedOrderIDs: make([]int, 0, len(c.completed)),
+	}
+
+	for _, b := range c.bots {
+		if b.CurrentOrder != nil {
+			s.BotSummaries = append(s.BotSummaries, fmt.Sprintf("bot#%d(%s order#%d)", b.ID, b.State, b.CurrentOrder.ID))
+		} else {
+			s.BotSummaries = append(s.BotSummaries, fmt.Sprintf("bot#%d(%s)", b.ID, b.State))
+		}
+	}
+	for _, o := range c.pendingVIP {
+		s.PendingVIPIDs = append(s.PendingVIPIDs, o.ID)
+	}
+	for _, o := range c.pendingNormal {
+		s.PendingNormalIDs = append(s.PendingNormalIDs, o.ID)
+	}
+	for _, o := range c.completed {
+		s.CompletedOrderIDs = append(s.CompletedOrderIDs, o.ID)
+	}
+	return s
+}
+
+// Metrics returns final summary counters for reporting.
+func (c *Controller) Metrics() Metrics {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return Metrics{
+		TotalOrders:   c.nextOrderID - 1000,
+		TotalVIP:      c.completedVIP + len(c.pendingVIP) + c.processingCountByType(OrderTypeVIP),
+		TotalNormal:   c.completedNorm + len(c.pendingNormal) + c.processingCountByType(OrderTypeNormal),
+		Completed:     len(c.completed),
+		ActiveBots:    len(c.bots),
+		PendingOrders: len(c.pendingVIP) + len(c.pendingNormal),
+	}
+}
+
+func (c *Controller) dispatch() {
+	for {
+		c.mu.Lock()
+		bot := c.findIdleBot()
+		if bot == nil {
+			c.mu.Unlock()
+			return
+		}
+		order := c.pickNextPending()
+		if order == nil {
+			c.mu.Unlock()
+			return
+		}
+
+		order.Status = OrderStatusProcessing
+		bot.State = BotStateBusy
+		bot.CurrentOrder = order
+
+		ctx, cancel := context.WithCancel(context.Background())
+		bot.cancel = cancel
+		botID := bot.ID
+		orderID := order.ID
+		c.logf("[%s] Bot #%d picked up %s Order #%d - Status: %s", hhmmss(), botID, displayOrderType(order.Type), orderID, order.Status)
+		c.mu.Unlock()
+
+		go c.processOrder(ctx, botID, orderID)
+	}
+}
+
+func (c *Controller) processOrder(ctx context.Context, botID, orderID int) {
+	timer := time.NewTimer(c.processingDuration)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		c.completeOrder(botID, orderID)
+	case <-ctx.Done():
+		return
+	}
+}
+
+func (c *Controller) completeOrder(botID, orderID int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	bot := c.findBotByID(botID)
+	if bot == nil || bot.CurrentOrder == nil {
+		return
+	}
+	if bot.CurrentOrder.ID != orderID || bot.CurrentOrder.Status != OrderStatusProcessing {
+		return
+	}
+
+	bot.CurrentOrder.Status = OrderStatusComplete
+	c.completed = append(c.completed, bot.CurrentOrder)
+	if bot.CurrentOrder.Type == OrderTypeVIP {
+		c.completedVIP++
+	} else {
+		c.completedNorm++
+	}
+	c.logf("[%s] Bot #%d completed %s Order #%d - Status: %s (Processing time: %ds)", hhmmss(), botID, displayOrderType(bot.CurrentOrder.Type), orderID, OrderStatusComplete, int(c.processingDuration.Seconds()))
+
+	bot.CurrentOrder = nil
+	bot.State = BotStateIdle
+	bot.cancel = nil
+	if len(c.pendingVIP)+len(c.pendingNormal) == 0 {
+		c.logf("[%s] Bot #%d is now IDLE - No pending orders", hhmmss(), botID)
+	}
+
+	// Trigger next dispatch in another goroutine to avoid lock re-entry complexity.
+	go c.dispatch()
+}
+
+func (c *Controller) findIdleBot() *Bot {
+	for _, b := range c.bots {
+		if b.State == BotStateIdle {
+			return b
+		}
+	}
+	return nil
+}
+
+func (c *Controller) findBotByID(botID int) *Bot {
+	for _, b := range c.bots {
+		if b.ID == botID {
+			return b
+		}
+	}
+	return nil
+}
+
+func (c *Controller) pickNextPending() *Order {
+	if len(c.pendingVIP) > 0 {
+		order := c.pendingVIP[0]
+		c.pendingVIP = c.pendingVIP[1:]
+		return order
+	}
+	if len(c.pendingNormal) > 0 {
+		order := c.pendingNormal[0]
+		c.pendingNormal = c.pendingNormal[1:]
+		return order
+	}
+	return nil
+}
+
+func hhmmss() string {
+	return time.Now().Format("15:04:05")
+}
+
+func (c *Controller) processingCountByType(orderType OrderType) int {
+	count := 0
+	for _, b := range c.bots {
+		if b.CurrentOrder != nil && b.CurrentOrder.Type == orderType && b.CurrentOrder.Status == OrderStatusProcessing {
+			count++
+		}
+	}
+	return count
+}
+
+func displayOrderType(orderType OrderType) string {
+	if orderType == OrderTypeVIP {
+		return "VIP"
+	}
+	return "Normal"
+}

--- a/internal/domain/controller_test.go
+++ b/internal/domain/controller_test.go
@@ -1,0 +1,240 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestVIPPriorityOverNormal(t *testing.T) {
+	c := NewController(500*time.Millisecond, nil)
+
+	normal := c.NewNormalOrder()
+	vip := c.NewVIPOrder()
+
+	s := c.Snapshot()
+	if len(s.PendingVIPIDs) != 1 || s.PendingVIPIDs[0] != vip.ID {
+		t.Fatalf("expected VIP pending first, got %+v", s.PendingVIPIDs)
+	}
+	if len(s.PendingNormalIDs) != 1 || s.PendingNormalIDs[0] != normal.ID {
+		t.Fatalf("expected normal pending list to keep normal order, got %+v", s.PendingNormalIDs)
+	}
+}
+
+func TestOrderIDIsIncreasing(t *testing.T) {
+	c := NewController(500*time.Millisecond, nil)
+	o1 := c.NewNormalOrder()
+	o2 := c.NewVIPOrder()
+	o3 := c.NewNormalOrder()
+	if !(o1.ID < o2.ID && o2.ID < o3.ID) {
+		t.Fatalf("expected increasing ids, got %d, %d, %d", o1.ID, o2.ID, o3.ID)
+	}
+}
+
+func TestBotProcessesOrderToComplete(t *testing.T) {
+	c := NewController(50*time.Millisecond, nil)
+	c.AddBot()
+	c.NewNormalOrder()
+	time.Sleep(100 * time.Millisecond)
+
+	s := c.Snapshot()
+	if len(s.CompletedOrderIDs) != 1 {
+		t.Fatalf("expected one completed order, got %+v", s.CompletedOrderIDs)
+	}
+}
+
+func TestRemoveBusyBotRequeuesOrder(t *testing.T) {
+	c := NewController(300*time.Millisecond, nil)
+	c.AddBot()
+	o := c.NewNormalOrder()
+	time.Sleep(20 * time.Millisecond)
+
+	if err := c.RemoveLatestBot(); err != nil {
+		t.Fatalf("unexpected error removing bot: %v", err)
+	}
+
+	s := c.Snapshot()
+	if len(s.PendingNormalIDs) != 1 || s.PendingNormalIDs[0] != o.ID {
+		t.Fatalf("expected order to be re-queued, got pending=%+v", s.PendingNormalIDs)
+	}
+	if len(s.CompletedOrderIDs) != 0 {
+		t.Fatalf("expected no completed order after cancellation, got %+v", s.CompletedOrderIDs)
+	}
+}
+
+func TestVIPStableFIFO(t *testing.T) {
+	c := NewController(500*time.Millisecond, nil)
+	v1 := c.NewVIPOrder()
+	v2 := c.NewVIPOrder()
+
+	s := c.Snapshot()
+	if s.PendingVIPIDs[0] != v1.ID || s.PendingVIPIDs[1] != v2.ID {
+		t.Fatalf("VIP orders should maintain FIFO among themselves")
+	}
+}
+
+func TestConcurrency(t *testing.T) {
+	c := NewController(10*time.Millisecond, nil)
+	c.AddBot()
+
+	const count = 100
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < count; i++ {
+			c.NewNormalOrder()
+			c.NewVIPOrder()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			c.AddBot()
+			time.Sleep(5 * time.Millisecond)
+			_ = c.RemoveLatestBot()
+		}
+	}()
+
+	wg.Wait()
+	time.Sleep(500 * time.Millisecond)
+
+	s := c.Snapshot()
+	seen := map[int]bool{}
+	duplicate := func(id int) {
+		if seen[id] {
+			t.Fatalf("duplicate order id found across snapshot views: %d", id)
+		}
+		seen[id] = true
+	}
+
+	for _, id := range s.PendingVIPIDs {
+		duplicate(id)
+	}
+	for _, id := range s.PendingNormalIDs {
+		duplicate(id)
+	}
+	for _, id := range s.CompletedOrderIDs {
+		duplicate(id)
+	}
+	for _, summary := range s.BotSummaries {
+		var id int
+		if _, err := fmt.Sscanf(summary, "bot#%*d(%*s order#%d)", &id); err == nil {
+			duplicate(id)
+		}
+	}
+}
+
+func TestRequeuedOrderPriority(t *testing.T) {
+	c := NewController(200*time.Millisecond, nil)
+	c.AddBot()
+	oNormal := c.NewNormalOrder()
+	time.Sleep(50 * time.Millisecond)
+
+	c.RemoveLatestBot()
+	oVIP := c.NewVIPOrder()
+
+	s := c.Snapshot()
+	if len(s.PendingVIPIDs) == 0 || len(s.PendingNormalIDs) == 0 {
+		t.Fatalf("expected both VIP and Normal pending queues to be non-empty, got VIP=%v Normal=%v", s.PendingVIPIDs, s.PendingNormalIDs)
+	}
+	if s.PendingVIPIDs[0] != oVIP.ID || s.PendingNormalIDs[0] != oNormal.ID {
+		t.Errorf("VIP should still be prioritized over re-queued Normal order")
+	}
+}
+
+func TestNormalStableFIFO(t *testing.T) {
+	c := NewController(500*time.Millisecond, nil)
+	n1 := c.NewNormalOrder()
+	n2 := c.NewNormalOrder()
+
+	s := c.Snapshot()
+	if len(s.PendingNormalIDs) != 2 {
+		t.Fatalf("expected two normal orders pending, got %v", s.PendingNormalIDs)
+	}
+	if s.PendingNormalIDs[0] != n1.ID || s.PendingNormalIDs[1] != n2.ID {
+		t.Fatalf("normal orders should maintain FIFO among themselves")
+	}
+}
+
+func TestRemoveLatestBotReturnsErrorWhenNoBot(t *testing.T) {
+	c := NewController(200*time.Millisecond, nil)
+	if err := c.RemoveLatestBot(); err == nil {
+		t.Fatalf("expected error when removing bot from empty pool")
+	}
+}
+
+func TestRemoveLatestBotUsesLIFOOrder(t *testing.T) {
+	c := NewController(200*time.Millisecond, nil)
+	c.AddBot()
+	c.AddBot()
+
+	if err := c.RemoveLatestBot(); err != nil {
+		t.Fatalf("unexpected error removing latest bot: %v", err)
+	}
+
+	s := c.Snapshot()
+	if len(s.BotSummaries) != 1 {
+		t.Fatalf("expected one bot left, got %v", s.BotSummaries)
+	}
+	if !strings.HasPrefix(s.BotSummaries[0], "bot#1(") {
+		t.Fatalf("expected bot#1 to remain after LIFO removal, got %v", s.BotSummaries)
+	}
+}
+
+func TestRemoveIdleBotDoesNotAffectPendingOrCompleted(t *testing.T) {
+	c := NewController(200*time.Millisecond, nil)
+	c.AddBot()
+	o := c.NewNormalOrder()
+	time.Sleep(220 * time.Millisecond)
+	c.AddBot()
+
+	before := c.Snapshot()
+	if err := c.RemoveLatestBot(); err != nil {
+		t.Fatalf("unexpected error removing idle bot: %v", err)
+	}
+	after := c.Snapshot()
+
+	if len(after.CompletedOrderIDs) != len(before.CompletedOrderIDs) {
+		t.Fatalf("removing idle bot should not change completed list, before=%v after=%v", before.CompletedOrderIDs, after.CompletedOrderIDs)
+	}
+	if len(after.PendingVIPIDs) != 0 || len(after.PendingNormalIDs) != 0 {
+		t.Fatalf("expected no pending orders, got VIP=%v Normal=%v", after.PendingVIPIDs, after.PendingNormalIDs)
+	}
+	if len(after.BotSummaries) != 1 || !strings.HasPrefix(after.BotSummaries[0], "bot#1(") {
+		t.Fatalf("expected only bot#1 to remain, got %v", after.BotSummaries)
+	}
+	if len(after.CompletedOrderIDs) != 1 || after.CompletedOrderIDs[0] != o.ID {
+		t.Fatalf("expected completed order to stay unchanged, got %v", after.CompletedOrderIDs)
+	}
+}
+
+func TestRemoveNearCompletionNeverLeavesOrderInBothStates(t *testing.T) {
+	c := NewController(120*time.Millisecond, nil)
+	c.AddBot()
+	o := c.NewNormalOrder()
+	time.Sleep(110 * time.Millisecond)
+	_ = c.RemoveLatestBot()
+	time.Sleep(40 * time.Millisecond)
+
+	s := c.Snapshot()
+	inPending := false
+	for _, id := range s.PendingNormalIDs {
+		if id == o.ID {
+			inPending = true
+		}
+	}
+	inCompleted := false
+	for _, id := range s.CompletedOrderIDs {
+		if id == o.ID {
+			inCompleted = true
+		}
+	}
+	if inPending && inCompleted {
+		t.Fatalf("order %d should not be both pending and completed", o.ID)
+	}
+}

--- a/internal/domain/order.go
+++ b/internal/domain/order.go
@@ -1,0 +1,34 @@
+package domain
+
+import "time"
+
+// OrderType declares the business priority group of an order.
+type OrderType string
+
+const (
+	// OrderTypeNormal is a regular customer order.
+	OrderTypeNormal OrderType = "NORMAL"
+	// OrderTypeVIP is a VIP member order.
+	OrderTypeVIP OrderType = "VIP"
+)
+
+// OrderStatus represents the order lifecycle in the controller.
+type OrderStatus string
+
+const (
+	// OrderStatusPending means the order is waiting for an available bot.
+	OrderStatusPending OrderStatus = "PENDING"
+	// OrderStatusProcessing means the order has been picked by a bot.
+	OrderStatusProcessing OrderStatus = "PROCESSING"
+	// OrderStatusComplete means the order has finished processing.
+	OrderStatusComplete OrderStatus = "COMPLETE"
+)
+
+// Order is the in-memory entity that flows through the system.
+type Order struct {
+	ID        int
+	Sequence  int
+	Type      OrderType
+	Status    OrderStatus
+	CreatedAt time.Time
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,13 +3,10 @@
 # Build Script
 # This script should contain all compilation steps for your CLI application
 
+set -e
+
 echo "Building CLI application..."
 
-# For Go projects:
-# go build -o order-controller ./cmd/main.go
-
-# For Node.js projects:
-# npm install
-# npm run build (if needed)
+go build -o order-controller ./cmd/order-controller
 
 echo "Build completed"

--- a/scripts/result.txt
+++ b/scripts/result.txt
@@ -1,23 +1,24 @@
 McDonald's Order Management System - Simulation Results
 
-[14:32:01] System initialized with 0 bots
-[14:32:01] Created Normal Order #1001 - Status: PENDING
-[14:32:02] Created VIP Order #1002 - Status: PENDING
-[14:32:02] Created Normal Order #1003 - Status: PENDING
-[14:32:03] Bot #1 created - Status: ACTIVE
-[14:32:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
-[14:32:04] Bot #2 created - Status: ACTIVE
-[14:32:04] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
-[14:32:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
-[14:32:13] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
-[14:32:14] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
-[14:32:14] Bot #2 is now IDLE - No pending orders
-[14:32:15] Created VIP Order #1004 - Status: PENDING
-[14:32:15] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
-[14:32:23] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 destroyed while IDLE
-[14:32:26] Bot #1 is now IDLE - No pending orders
+[21:50:00] System initialized with 0 bots
+[21:50:00] Created Normal Order #1001 - Status: PENDING
+[21:50:00] Created VIP Order #1002 - Status: PENDING
+[21:50:00] Created Normal Order #1003 - Status: PENDING
+[21:50:00] Bot #1 created - Status: ACTIVE
+[21:50:00] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
+[21:50:01] Bot #2 created - Status: ACTIVE
+[21:50:01] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
+[21:50:10] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
+[21:50:10] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
+[21:50:11] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
+[21:50:11] Bot #2 is now IDLE - No pending orders
+[21:50:12] Created VIP Order #1004 - Status: PENDING
+[21:50:12] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
+[21:50:20] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
+[21:50:20] Bot #1 is now IDLE - No pending orders
+[21:50:22] Bot #2 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
+[21:50:22] Bot #2 is now IDLE - No pending orders
+[21:50:23] Bot #2 destroyed while IDLE
 
 Final Status:
 - Total Orders Processed: 4 (2 VIP, 2 Normal)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,17 +3,27 @@
 # Run Script
 # This script should execute your CLI application and output results to result.txt
 
+set -e
+
 echo "Running CLI application..."
 
-# For Go projects:
-# ./order-controller > result.txt
+echo "McDonald's Order Management System - Simulation Results" > scripts/result.txt
+echo "" >> scripts/result.txt
 
-# For Node.js projects:
-# node index.js > result.txt
-# or npm start > result.txt
-
-# Temporary placeholder - remove this when you implement your CLI
-echo "Added 1 bot" > result.txt
-echo "status: bot: [1], order: []" >> result.txt
+cat <<'EOF' | ./order-controller >> scripts/result.txt
+new normal
+new vip
+new normal
+add bot
+sleep 1
+add bot
+sleep 11
+new vip
+sleep 11
+remove bot
+sleep 1
+summary
+exit
+EOF
 
 echo "CLI application execution completed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,12 +3,10 @@
 # Unit Test Script
 # This script should contain all unit test execution steps
 
+set -e
+
 echo "Running unit tests..."
 
-# For Go projects:
-# go test ./... -v
-
-# For Node.js projects:
-# npm test
+go test ./... -race -v
 
 echo "Unit tests completed"


### PR DESCRIPTION
## Summary

Implement the Go CLI backend for McDonald's order management simulation.

### Included in this PR

- Added in-memory order controller with VIP-first scheduling and FIFO queue behavior
- Implemented bot lifecycle management (`add bot` / `remove bot`) with busy-bot cancellation and re-queue
- Added CLI command handling (`new normal`, `new vip`, `add/remove bot`, `status`, `summary`, etc.)
- Implemented required scripts: `scripts/test.sh`, `scripts/build.sh`, `scripts/run.sh`
- Generated `scripts/result.txt` with `HH:MM:SS` timestamps and final summary output
- Added race-enabled tests and edge-case coverage for controller behavior
- Added project documentation in `docs/backend-solution.md`

## Verification

```bash
./scripts/test.sh
./scripts/build.sh
./scripts/run.sh
cat scripts/result.txt