### PR TITLE
feat: implement order controller cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/order-controller

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,12 +1,12 @@
 # McDonald's Order Controller - Go 实现说明
 
-这是一个基于 Go 的 CLI 原型，用来模拟 McDonald's 自动烹饪 bot 的订单控制系统。实现目标是满足 README 中 backend 方向的要求：使用 Go 编写 CLI，提供 `test.sh`、`build.sh`、`run.sh`，并将运行结果输出到 `scripts/result.txt`。
+这是一个基于 Go 的 CLI 原型，用来模拟 McDonald's 自动烹饪 bot 的订单控制系统。CLI 入口使用 `urfave/cli/v2` 处理 `--simulate` 和 `--interactive` 模式。实现目标是满足 README 中 backend 方向的要求：使用 Go 编写 CLI，提供 `test.sh`、`build.sh`、`run.sh`，并将运行结果输出到 `scripts/result.txt`。
 
 ## 项目结构
 
 ```text
 ├── cmd/
-│   └── main.go                    # CLI 入口，运行一段完整模拟流程
+│   └── main.go                    # CLI 入口，支持自动模拟和交互命令
 ├── internal/
 │   └── controller/
 │       ├── controller.go          # 订单控制核心逻辑
@@ -37,7 +37,7 @@
 3. 订单队列、bot 列表、完成列表等可变状态只由 coordinator goroutine 读写。
 4. bot 接单后会启动独立的订单制作 goroutine，内部用 timer 模拟 10 秒制作耗时；制作 goroutine 不直接修改状态，只会发回 `CompleteOrder` 命令。
 
-这样既使用了 Go 的 channel 来协调并发，又避免多个 goroutine 同时读写订单队列，因此核心状态不需要 mutex。controller 关闭时使用 `done chan struct{}` 通知后台订单制作 goroutine 退出；这个作业只需要一个简单的广播停止信号，所以没有引入 context。
+这样既使用了 Go 的 channel 来协调并发，又避免多个 goroutine 同时读写订单队列，因此核心状态不需要 mutex。controller 关闭时使用 `done chan struct{}` 通知后台订单制作 goroutine 退出；每个正在制作的订单也有独立的 cancel function，用来在删除对应 bot 时立即停止制作。
 
 ## 关键组件
 
@@ -45,13 +45,13 @@
 
 - `ID`：唯一递增订单号。
 - `Type`：订单类型，包含 `Normal` 和 `VIP`。
-- `Status`：订单状态，当前订单快照中主要体现 `PENDING` 和 `COMPLETE`；正在处理的订单由 bot 的 `PROCESSING` 状态表示。
+- `Status`：订单状态，包含 `PENDING`、`PROCESSING` 和 `COMPLETE`。
 
 ### Bot
 
 - `ID`：唯一递增 bot 编号。
 - `Status`：bot 状态，包含 `IDLE` 和 `PROCESSING`。
-- `CurrentOrderID`：当前正在处理的订单 ID。
+- `CurrentOrder`：当前正在处理的订单，订单状态为 `PROCESSING`。
 
 ### Controller
 
@@ -62,23 +62,22 @@
 - 调度 pending 订单给 idle bot。
 - 接收订单完成事件。
 - 返回系统当前状态快照。
-- 通过 `Completed()` 暴露只读完成事件 channel，供 CLI 等待模拟流程继续执行。
 
 ## Pending 队列设计
 
-为了让优先级逻辑更清楚，pending 订单没有使用一个混合队列再排序，而是拆成两个 FIFO 队列：
+pending 订单使用一个队列保存，队列本身始终保持业务优先级顺序：
 
-- `vipPending`
-- `normalPending`
+1. VIP 订单排在普通订单前面。
+2. 同类型订单按 `Order.ID` 升序排列。
 
-调度时永远先取 `vipPending`，如果 VIP 队列为空，再取 `normalPending`。新增订单和被取消的订单都会回到对应类型队列的尾部。
+新增订单和被取消的订单都会通过同一套插入逻辑回到 pending 队列。这样删除 bot 后退回订单时，不需要记额外的原始位置，也能恢复到符合下单顺序的位置。
 
 这个设计的好处是：
 
-- 不需要排序。
+- 数据结构更贴近 UI/CLI 里看到的单个 pending 区域。
 - 不需要额外的 sequence 字段。
 - VIP 优先级规则直观。
-- 同类型 FIFO 顺序由 slice append 和从头 pop 自然保证。
+- 同类型 FIFO 顺序由 `Order.ID` 和从头 pop 保证。
 
 ## 并发与取消安全
 
@@ -87,7 +86,7 @@ bot 接到订单后会启动一个订单制作 goroutine。这个 goroutine 用 
 - bot ID
 - order ID
 
-如果 bot 在处理过程中被删除，订单会回到 pending 队列，而该 bot 会从 active bot 列表中移除。之后旧制作 goroutine 即使触发完成命令，也会因为找不到匹配的 active bot 而被忽略。
+如果 bot 在处理过程中被删除，订单会按 ID 插回 pending 队列，而该 bot 会从 active bot 列表中移除。删除 bot 时会调用该 bot 当前制作任务的 cancel function，立即停止对应制作 goroutine。之后旧完成事件即使在极端时序下抵达，也会因为找不到匹配的 active bot 而被忽略。
 
 这避免了一个常见竞态：订单已经退回 pending，但旧 goroutine 又把它标记为 complete。
 
@@ -99,7 +98,7 @@ bot 接到订单后会启动一个订单制作 goroutine。这个 goroutine 用 
 
 ### 2. VIP 订单优先
 
-VIP 订单进入 `vipPending`，调度时始终优先于普通订单。同为 VIP 的订单仍保持 FIFO。
+VIP 订单进入 pending 队列时会排在普通订单前面。同为 VIP 的订单仍按 `Order.ID` 保持 FIFO。
 
 ### 3. 订单号唯一递增
 
@@ -107,7 +106,7 @@ VIP 订单进入 `vipPending`，调度时始终优先于普通订单。同为 VI
 
 ### 4. bot 处理订单
 
-`AddBot` 会创建新 bot，并立即尝试从 pending 队列取单。每个订单需要 10 秒处理，完成后进入 completed 列表。
+`AddBot` 会创建新 bot，并立即尝试从 pending 队列取单。订单被 bot 取走后状态变为 `PROCESSING`。每个订单需要 10 秒处理，完成后状态变为 `COMPLETE` 并进入 completed 列表。
 
 ### 5. bot 空闲状态
 
@@ -115,7 +114,7 @@ VIP 订单进入 `vipPending`，调度时始终优先于普通订单。同为 VI
 
 ### 6. 删除 bot
 
-`RemoveBot` 删除最新创建的 bot。如果该 bot 正在处理订单，订单会回到对应 pending 队列，并继续遵循 VIP/Normal 优先级。
+`RemoveBot` 删除最新创建的 bot。如果该 bot 正在处理订单，订单会从 `PROCESSING` 变回 `PENDING`，回到 pending 队列，并继续遵循 VIP/Normal 优先级。
 
 ### 7. 内存处理
 
@@ -127,6 +126,8 @@ VIP 订单进入 `vipPending`，调度时始终优先于普通订单。同为 VI
 
 - VIP 订单优先于普通订单被派发。
 - 删除正在处理的 bot 后，订单返回 pending 队列。
+- 退回 pending 的订单按 `Order.ID` 回到同类型队列中的正确位置。
+- 删除正在处理的 bot 会立即取消对应制作任务。
 - 删除 bot 后，旧订单制作 goroutine 的完成事件会被忽略。
 - bot 完成订单后会继续处理下一个优先级最高的订单。
 
@@ -144,9 +145,27 @@ VIP 订单进入 `vipPending`，调度时始终优先于普通订单。同为 VI
 ./scripts/run.sh
 ```
 
-`build.sh` 会生成根目录下的 `order-controller` 二进制文件。`run.sh` 只运行这个已编译好的程序，并将输出写入 `scripts/result.txt`。
+`build.sh` 会生成根目录下的 `order-controller` 二进制文件。`run.sh` 会以 `--simulate` 模式运行这个已编译好的程序，并将输出写入 `scripts/result.txt`。
 
-CLI 会先调用 `mockCommand` 模拟一组操作命令，包括下单、增加 bot、稍后新增 VIP 订单、最后删除 bot。controller 会在后台异步处理订单并把完成事件写入 `Completed()` channel。随后主流程阻塞监听完成事件和一个 `time.NewTimer`：每收到一个完成事件就重置 11 秒计时；如果连续 11 秒没有新的完成事件，就认为模拟流程已经没有更多订单完成，随后输出最终状态并返回。这样 `run.sh` 在 GitHub Actions 中仍然可以自动结束并生成稳定结果。
+交互 CLI 可以通过下面命令启动：
+
+```bash
+./order-controller --interactive
+```
+
+支持的交互命令包括：
+
+```text
+normal / n        创建普通订单
+vip / v           创建 VIP 订单
++ / add bot       增加 cooking bot
+- / remove bot    删除最新 cooking bot
+status / s        查看当前状态
+help / h          查看命令帮助
+exit / q          退出
+```
+
+CLI 会先调用 `mockCommand` 模拟一组操作命令，包括下单、增加 bot、稍后新增 VIP 订单、最后删除 bot。controller 会在后台异步处理订单。随后主流程固定等待一段足够覆盖剩余订单制作的时间，再输出最终状态并返回。这样 `run.sh` 在 GitHub Actions 中仍然可以自动结束并生成稳定结果。
 
 ## 输出说明
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,0 +1,162 @@
+# McDonald's Order Controller - Go 实现说明
+
+这是一个基于 Go 的 CLI 原型，用来模拟 McDonald's 自动烹饪 bot 的订单控制系统。实现目标是满足 README 中 backend 方向的要求：使用 Go 编写 CLI，提供 `test.sh`、`build.sh`、`run.sh`，并将运行结果输出到 `scripts/result.txt`。
+
+## 项目结构
+
+```text
+├── cmd/
+│   └── main.go                    # CLI 入口，运行一段完整模拟流程
+├── internal/
+│   └── controller/
+│       ├── controller.go          # 订单控制核心逻辑
+│       └── controller_test.go     # 单元测试
+├── scripts/
+│   ├── build.sh                   # 编译 CLI 程序
+│   ├── run.sh                     # 运行已编译程序并生成 result.txt
+│   ├── test.sh                    # 执行单元测试
+│   └── result.txt                 # CLI 输出结果
+├── IMPLEMENTATION.md              # 本实现说明
+├── go.mod                         # Go module 定义
+└── README.md                      # 原始作业说明
+```
+
+## 核心设计
+
+本实现没有把订单直接放进 channel 里做生产者消费者模型。原因是这个业务不是单纯 FIFO：
+
+- VIP 订单需要优先于普通订单。
+- 同类型订单需要保持 FIFO。
+- bot 被删除时，如果正在处理订单，订单需要回到 pending 队列。
+- 旧的处理 goroutine 不能在订单被退回后又错误地把它标记为 complete。
+
+因此，这里采用 **coordinator/actor 模型**：
+
+1. `Controller` 内部启动一个 coordinator goroutine。
+2. 外部调用 `NewOrder`、`AddBot`、`RemoveBot`、`Snapshot` 时，只是向 `commands` channel 发送命令。
+3. 订单队列、bot 列表、完成列表等可变状态只由 coordinator goroutine 读写。
+4. bot 接单后会启动独立的订单制作 goroutine，内部用 timer 模拟 10 秒制作耗时；制作 goroutine 不直接修改状态，只会发回 `CompleteOrder` 命令。
+
+这样既使用了 Go 的 channel 来协调并发，又避免多个 goroutine 同时读写订单队列，因此核心状态不需要 mutex。controller 关闭时使用 `done chan struct{}` 通知后台订单制作 goroutine 退出；这个作业只需要一个简单的广播停止信号，所以没有引入 context。
+
+## 关键组件
+
+### Order
+
+- `ID`：唯一递增订单号。
+- `Type`：订单类型，包含 `Normal` 和 `VIP`。
+- `Status`：订单状态，当前订单快照中主要体现 `PENDING` 和 `COMPLETE`；正在处理的订单由 bot 的 `PROCESSING` 状态表示。
+
+### Bot
+
+- `ID`：唯一递增 bot 编号。
+- `Status`：bot 状态，包含 `IDLE` 和 `PROCESSING`。
+- `CurrentOrderID`：当前正在处理的订单 ID。
+
+### Controller
+
+`Controller` 是系统核心，负责：
+
+- 创建普通订单和 VIP 订单。
+- 增加或删除 bot。
+- 调度 pending 订单给 idle bot。
+- 接收订单完成事件。
+- 返回系统当前状态快照。
+- 通过 `Completed()` 暴露只读完成事件 channel，供 CLI 等待模拟流程继续执行。
+
+## Pending 队列设计
+
+为了让优先级逻辑更清楚，pending 订单没有使用一个混合队列再排序，而是拆成两个 FIFO 队列：
+
+- `vipPending`
+- `normalPending`
+
+调度时永远先取 `vipPending`，如果 VIP 队列为空，再取 `normalPending`。新增订单和被取消的订单都会回到对应类型队列的尾部。
+
+这个设计的好处是：
+
+- 不需要排序。
+- 不需要额外的 sequence 字段。
+- VIP 优先级规则直观。
+- 同类型 FIFO 顺序由 slice append 和从头 pop 自然保证。
+
+## 并发与取消安全
+
+bot 接到订单后会启动一个订单制作 goroutine。这个 goroutine 用 timer 模拟 10 秒制作耗时，结束后发送完成命令。coordinator 只有在以下信息仍然匹配时才会完成订单：
+
+- bot ID
+- order ID
+
+如果 bot 在处理过程中被删除，订单会回到 pending 队列，而该 bot 会从 active bot 列表中移除。之后旧制作 goroutine 即使触发完成命令，也会因为找不到匹配的 active bot 而被忽略。
+
+这避免了一个常见竞态：订单已经退回 pending，但旧 goroutine 又把它标记为 complete。
+
+## 已实现需求
+
+### 1. 普通订单创建
+
+调用 `NewOrder(Normal)` 后会创建唯一递增订单，并进入 pending 队列。
+
+### 2. VIP 订单优先
+
+VIP 订单进入 `vipPending`，调度时始终优先于普通订单。同为 VIP 的订单仍保持 FIFO。
+
+### 3. 订单号唯一递增
+
+订单 ID 从 1 开始递增，由 coordinator goroutine 单独维护。
+
+### 4. bot 处理订单
+
+`AddBot` 会创建新 bot，并立即尝试从 pending 队列取单。每个订单需要 10 秒处理，完成后进入 completed 列表。
+
+### 5. bot 空闲状态
+
+如果没有 pending 订单，bot 保持 `IDLE`。后续有新订单进入时，controller 会再次尝试分配给 idle bot。
+
+### 6. 删除 bot
+
+`RemoveBot` 删除最新创建的 bot。如果该 bot 正在处理订单，订单会回到对应 pending 队列，并继续遵循 VIP/Normal 优先级。
+
+### 7. 内存处理
+
+所有状态都保存在内存中，没有数据库或文件持久化。
+
+## 测试覆盖
+
+单元测试覆盖了几个关键行为：
+
+- VIP 订单优先于普通订单被派发。
+- 删除正在处理的 bot 后，订单返回 pending 队列。
+- 删除 bot 后，旧订单制作 goroutine 的完成事件会被忽略。
+- bot 完成订单后会继续处理下一个优先级最高的订单。
+
+测试命令：
+
+```bash
+./scripts/test.sh
+```
+
+## 使用方式
+
+```bash
+./scripts/test.sh
+./scripts/build.sh
+./scripts/run.sh
+```
+
+`build.sh` 会生成根目录下的 `order-controller` 二进制文件。`run.sh` 只运行这个已编译好的程序，并将输出写入 `scripts/result.txt`。
+
+CLI 会先调用 `mockCommand` 模拟一组操作命令，包括下单、增加 bot、稍后新增 VIP 订单、最后删除 bot。controller 会在后台异步处理订单并把完成事件写入 `Completed()` channel。随后主流程阻塞监听完成事件和一个 `time.NewTimer`：每收到一个完成事件就重置 11 秒计时；如果连续 11 秒没有新的完成事件，就认为模拟流程已经没有更多订单完成，随后输出最终状态并返回。这样 `run.sh` 在 GitHub Actions 中仍然可以自动结束并生成稳定结果。
+
+## 输出说明
+
+`scripts/result.txt` 会包含一段完整模拟流程，展示：
+
+- 创建普通订单和 VIP 订单。
+- 增加 bot。
+- VIP 订单优先处理。
+- 订单在 10 秒后完成。
+- bot 空闲和删除。
+- 最终订单统计。
+
+所有关键日志都包含 `HH:MM:SS` 格式时间戳，以满足 GitHub Actions 中对 `result.txt` 的校验要求。

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"feedmepos_homework/internal/controller"
+)
+
+func main() {
+	c := controller.NewController(os.Stdout)
+	defer c.Stop()
+
+	fmt.Println("McDonald's Order Management System - CLI Simulation")
+	fmt.Printf("[%s] System initialized with 0 bots\n", time.Now().Format("15:04:05"))
+
+	mockCommand(c)
+
+	waitForCompletions(c.Completed(), 11*time.Second)
+	printFinalStatus(c.Snapshot())
+}
+
+func mockCommand(c *controller.Controller) {
+	c.NewOrder(controller.Normal)
+	c.NewOrder(controller.Normal)
+	c.NewOrder(controller.VIP)
+	c.NewOrder(controller.Normal)
+
+	time.Sleep(1 * time.Second)
+	c.AddBot()
+
+	time.Sleep(1 * time.Second)
+	c.AddBot()
+
+	// Wait for orders to complete (10+ seconds each)
+	time.Sleep(12 * time.Second)
+	c.NewOrder(controller.VIP)
+	time.Sleep(1 * time.Second)
+
+	c.RemoveBot()
+}
+
+// waitForCompletions 会一直等订单完成事件。
+// 每完成一单就重新计时；如果连续一段时间没有新订单完成，就认为模拟流程结束。
+func waitForCompletions(completed <-chan controller.Order, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-completed:
+			timer.Reset(timeout)
+		case <-timer.C:
+			return
+		}
+	}
+}
+
+func printFinalStatus(snapshot controller.Snapshot) {
+	vipCompleted := 0
+	normalCompleted := 0
+	for _, order := range snapshot.Completed {
+		if order.Type == controller.VIP {
+			vipCompleted++
+		} else {
+			normalCompleted++
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Final Status:")
+	fmt.Printf("- Total Orders Processed: %d (%d VIP, %d Normal)\n", len(snapshot.Completed), vipCompleted, normalCompleted)
+	fmt.Printf("- Orders Completed: %d\n", len(snapshot.Completed))
+	fmt.Printf("- Active Bots: %d\n", len(snapshot.Bots))
+	fmt.Printf("- Pending Orders: %d\n", len(snapshot.Pending))
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,14 +1,53 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"feedmepos_homework/internal/controller"
+
+	"github.com/urfave/cli/v2"
 )
 
 func main() {
+	app := &cli.App{
+		Name:  "order-controller",
+		Usage: "McDonald's cooking bot order controller",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "simulate", Usage: "run the automated CLI simulation"},
+			&cli.BoolFlag{Name: "interactive", Usage: "run the interactive CLI"},
+		},
+		Action: func(ctx *cli.Context) error {
+			if shouldRunInteractive(ctx.Bool("simulate"), ctx.Bool("interactive")) {
+				runInteractiveCLI()
+				return nil
+			}
+			runSimulation()
+			return nil
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func shouldRunInteractive(simulate, interactive bool) bool {
+	if simulate {
+		return false
+	}
+	if interactive {
+		return true
+	}
+	stat, err := os.Stdin.Stat()
+	return err == nil && (stat.Mode()&os.ModeCharDevice) != 0
+}
+
+func runSimulation() {
 	c := controller.NewController(os.Stdout)
 	defer c.Stop()
 
@@ -17,8 +56,66 @@ func main() {
 
 	mockCommand(c)
 
-	waitForCompletions(c.Completed(), 11*time.Second)
+	time.Sleep(20 * time.Second)
 	printFinalStatus(c.Snapshot())
+}
+
+func runInteractiveCLI() {
+	c := controller.NewController(os.Stdout)
+	defer c.Stop()
+
+	fmt.Println("McDonald's Order Management System - Interactive CLI")
+	fmt.Println("Type help to list commands.")
+	fmt.Printf("[%s] System initialized with 0 bots\n", time.Now().Format("15:04:05"))
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("\nMcDonald's CLI> ")
+		if !scanner.Scan() {
+			fmt.Println()
+			return
+		}
+		if executeCLICommand(c, scanner.Text()) {
+			return
+		}
+	}
+}
+
+func executeCLICommand(c *controller.Controller, input string) bool {
+	cmd := strings.TrimSpace(strings.ToLower(input))
+	switch cmd {
+	case "":
+		return false
+	case "normal", "n", "new normal", "new normal order":
+		c.NewOrder(controller.Normal)
+	case "vip", "v", "new vip", "new vip order":
+		c.NewOrder(controller.VIP)
+	case "+", "+ bot", "add bot":
+		c.AddBot()
+	case "-", "- bot", "remove bot":
+		c.RemoveBot()
+	case "status", "s":
+		printFinalStatus(c.Snapshot())
+	case "help", "h":
+		printHelp()
+	case "exit", "quit", "q":
+		fmt.Println("Shutting down McDonald's Order Management System.")
+		return true
+	default:
+		fmt.Printf("Unknown command %q. Type help to list commands.\n", cmd)
+	}
+	return false
+}
+
+func printHelp() {
+	fmt.Println("Available commands:")
+	fmt.Println("  normal | n        Create a normal order")
+	fmt.Println("  vip | v           Create a VIP order")
+	fmt.Println("  + | add bot       Add a cooking bot")
+	fmt.Println("  - | remove bot    Remove the newest cooking bot")
+	fmt.Println("  status | s        Print current system status")
+	fmt.Println("  help | h          Print this help")
+	fmt.Println("  exit | q          Exit interactive CLI")
 }
 
 func mockCommand(c *controller.Controller) {
@@ -39,22 +136,6 @@ func mockCommand(c *controller.Controller) {
 	time.Sleep(1 * time.Second)
 
 	c.RemoveBot()
-}
-
-// waitForCompletions 会一直等订单完成事件。
-// 每完成一单就重新计时；如果连续一段时间没有新订单完成，就认为模拟流程结束。
-func waitForCompletions(completed <-chan controller.Order, timeout time.Duration) {
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-completed:
-			timer.Reset(timeout)
-		case <-timer.C:
-			return
-		}
-	}
 }
 
 func printFinalStatus(snapshot controller.Snapshot) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"feedmepos_homework/internal/controller"
+)
+
+func TestExecuteCLICommandHandlesOrderAndBotCommands(t *testing.T) {
+	c := controller.NewController(io.Discard)
+	defer c.Stop()
+
+	if exit := executeCLICommand(c, "normal"); exit {
+		t.Fatal("normal command should not exit")
+	}
+	executeCLICommand(c, "vip")
+	executeCLICommand(c, "+ bot")
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Bots) != 1 {
+		t.Fatalf("bots = %+v, want one bot", snapshot.Bots)
+	}
+	if len(snapshot.Pending) != 1 || snapshot.Pending[0].Type != controller.Normal {
+		t.Fatalf("pending = %+v, want remaining normal order", snapshot.Pending)
+	}
+	if snapshot.Bots[0].CurrentOrder == nil || snapshot.Bots[0].CurrentOrder.ID != 2 {
+		t.Fatalf("bot current order = %+v, want VIP order 2", snapshot.Bots[0].CurrentOrder)
+	}
+}
+
+func TestExecuteCLICommandIgnoresBlankCommand(t *testing.T) {
+	c := controller.NewController(io.Discard)
+	defer c.Stop()
+
+	if exit := executeCLICommand(c, " "); exit {
+		t.Fatal("blank command should not exit")
+	}
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Bots) != 0 || len(snapshot.Pending) != 0 || len(snapshot.Completed) != 0 {
+		t.Fatalf("snapshot = %+v, want no state changes", snapshot)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module feedmepos_homework
 
 go 1.23
+
+require github.com/urfave/cli/v2 v2.27.7
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module feedmepos_homework
+
+go 1.23

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
+github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
+github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,0 +1,344 @@
+package controller
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+const processingDuration = 10 * time.Second
+
+type OrderType int
+
+const (
+	Normal OrderType = iota
+	VIP
+)
+
+func (t OrderType) String() string {
+	if t == VIP {
+		return "VIP"
+	}
+	return "Normal"
+}
+
+type OrderStatus string
+
+const (
+	OrderPending  OrderStatus = "PENDING"
+	OrderComplete OrderStatus = "COMPLETE"
+)
+
+type BotStatus string
+
+const (
+	BotIdle       BotStatus = "IDLE"
+	BotProcessing BotStatus = "PROCESSING"
+)
+
+type Order struct {
+	ID     int
+	Type   OrderType
+	Status OrderStatus
+}
+
+type Bot struct {
+	ID             int
+	Status         BotStatus
+	CurrentOrderID int
+	currentType    OrderType
+}
+
+type Snapshot struct {
+	Pending   []Order
+	Completed []Order
+	Bots      []Bot
+}
+
+// Controller 通过 commands channel 串行化所有状态变更。
+// pending 队列和 bot 列表只会在 run 这个 goroutine 里读写，因此不需要 mutex。
+type Controller struct {
+	commands  chan command
+	completed chan Order
+	done      chan struct{}
+	logWriter io.Writer
+}
+
+type commandKind int
+
+const (
+	cmdNewOrder commandKind = iota
+	cmdAddBot
+	cmdRemoveBot
+	cmdCompleteOrder
+	cmdSnapshot
+	cmdStop
+)
+
+type command struct {
+	kind    commandKind
+	orderTy OrderType
+	botID   int
+	orderID int
+	reply   chan response
+}
+
+type response struct {
+	order    *Order
+	bot      *Bot
+	snapshot Snapshot
+}
+
+func NewController(logWriter io.Writer) *Controller {
+	c := &Controller{
+		commands: make(chan command),
+		// completed 只用于通知外部“有订单完成了”，容量给一点缓冲，避免 CLI 短时间没读取时卡住 controller。
+		completed: make(chan Order, 16),
+		done:      make(chan struct{}),
+		logWriter: logWriter,
+	}
+	go c.run()
+	return c
+}
+
+func (c *Controller) NewOrder(orderType OrderType) *Order {
+	reply := make(chan response)
+	c.commands <- command{kind: cmdNewOrder, orderTy: orderType, reply: reply}
+	return (<-reply).order
+}
+
+func (c *Controller) AddBot() *Bot {
+	reply := make(chan response)
+	c.commands <- command{kind: cmdAddBot, reply: reply}
+	return (<-reply).bot
+}
+
+func (c *Controller) RemoveBot() *Bot {
+	reply := make(chan response)
+	c.commands <- command{kind: cmdRemoveBot, reply: reply}
+	return (<-reply).bot
+}
+
+func (c *Controller) Snapshot() Snapshot {
+	reply := make(chan response)
+	c.commands <- command{kind: cmdSnapshot, reply: reply}
+	return (<-reply).snapshot
+}
+
+// Completed 返回只读 channel，外部可以用它等待订单真正制作完成。
+func (c *Controller) Completed() <-chan Order {
+	return c.completed
+}
+
+func (c *Controller) Stop() {
+	reply := make(chan response)
+	c.commands <- command{kind: cmdStop, reply: reply}
+	<-reply
+	close(c.done)
+}
+
+// run 是 controller 的状态中心。外部 API 和订单制作 goroutine 都只发送命令，
+// 真正修改订单、队列、bot 状态的逻辑都收敛在这里。
+func (c *Controller) run() {
+	var vipPending []Order
+	var normalPending []Order
+	var completed []Order
+	var bots []Bot
+	nextOrderID := 1
+	nextBotID := 1
+
+	for cmd := range c.commands {
+		switch cmd.kind {
+		case cmdNewOrder:
+			order := Order{
+				ID:     nextOrderID,
+				Type:   cmd.orderTy,
+				Status: OrderPending,
+			}
+			nextOrderID++
+			addPendingOrder(&vipPending, &normalPending, order)
+			c.log("%s Order #%d created - Status: PENDING", order.Type, order.ID)
+			c.dispatchOrders(&vipPending, &normalPending, &bots)
+			cmd.reply <- response{order: copyOrder(order)}
+
+		case cmdAddBot:
+			bot := Bot{ID: nextBotID, Status: BotIdle}
+			nextBotID++
+			bots = append(bots, bot)
+			c.log("Bot #%d created - Status: ACTIVE", bot.ID)
+			c.dispatchOrders(&vipPending, &normalPending, &bots)
+			created := findBot(bots, bot.ID)
+			cmd.reply <- response{bot: copyBot(created)}
+
+		case cmdRemoveBot:
+			if len(bots) == 0 {
+				cmd.reply <- response{}
+				continue
+			}
+			// 作业要求删除“最后一个 bot”。如果它正在制作订单，需要把订单退回 pending 队列。
+			removed := bots[len(bots)-1]
+			bots = bots[:len(bots)-1]
+			if removed.Status == BotProcessing {
+				order := pendingOrderFromBot(removed)
+				addPendingOrder(&vipPending, &normalPending, order)
+				c.log("Bot #%d destroyed while PROCESSING - %s Order #%d returned to PENDING", removed.ID, order.Type, order.ID)
+			} else {
+				c.log("Bot #%d destroyed while IDLE", removed.ID)
+			}
+			cmd.reply <- response{bot: copyBot(&removed)}
+
+		case cmdCompleteOrder:
+			bot := findBot(bots, cmd.botID)
+			if bot == nil || bot.Status != BotProcessing || bot.CurrentOrderID != cmd.orderID {
+				continue
+			}
+			order := Order{
+				ID:     cmd.orderID,
+				Type:   bot.currentType,
+				Status: OrderComplete,
+			}
+			completed = append(completed, order)
+			c.log("Bot #%d completed %s Order #%d - Status: COMPLETE (Processing time: 10s)", bot.ID, order.Type, order.ID)
+			c.notifyCompleted(order)
+			bot.Status = BotIdle
+			bot.CurrentOrderID = 0
+			c.dispatchOrders(&vipPending, &normalPending, &bots)
+			// dispatchOrders 可能会立刻把下一单分配给这个 bot，所以这里要重新检查它是否仍然 idle。
+			if bot.Status == BotIdle && countPendingOrders(vipPending, normalPending) == 0 {
+				c.log("Bot #%d is now IDLE - No pending orders", bot.ID)
+			}
+
+		case cmdSnapshot:
+			// 返回快照时复制 slice，避免外部拿到内部状态的引用后误改 controller 状态。
+			cmd.reply <- response{snapshot: Snapshot{
+				Pending:   listPendingOrders(vipPending, normalPending),
+				Completed: append([]Order(nil), completed...),
+				Bots:      append([]Bot(nil), bots...),
+			}}
+
+		case cmdStop:
+			cmd.reply <- response{}
+			return
+		}
+	}
+}
+
+// dispatchOrders 尽可能把 pending 订单派给空闲 bot。
+// 具体优先级由 popNextOrder 决定：VIP 队列优先，其次普通队列。
+func (c *Controller) dispatchOrders(vipPending, normalPending *[]Order, bots *[]Bot) {
+	for countPendingOrders(*vipPending, *normalPending) > 0 {
+		bot := firstIdleBot(*bots)
+		if bot == nil {
+			return
+		}
+		order := popNextOrder(vipPending, normalPending)
+		bot.Status = BotProcessing
+		bot.CurrentOrderID = order.ID
+		bot.currentType = order.Type
+		c.log("Bot #%d picked up %s Order #%d - Status: PROCESSING", bot.ID, order.Type, order.ID)
+		c.makeOrder(bot.ID, order.ID)
+	}
+}
+
+// makeOrder 模拟真实的订单制作过程。
+// 制作耗时不放在 run 里等待，否则 controller 就无法继续处理新订单、加 bot、删 bot 等命令。
+// 制作完成后只发回 cmdCompleteOrder，由 run 统一判断这次完成事件是否仍然有效。
+func (c *Controller) makeOrder(botID, orderID int) {
+	go func() {
+		timer := time.NewTimer(processingDuration)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			select {
+			case c.commands <- command{kind: cmdCompleteOrder, botID: botID, orderID: orderID}:
+			case <-c.done:
+			}
+		case <-c.done:
+		}
+	}()
+}
+
+// notifyCompleted 只负责通知外部有订单完成，不参与 controller 内部状态修改。
+func (c *Controller) notifyCompleted(order Order) {
+	select {
+	case c.completed <- order:
+	case <-c.done:
+	}
+}
+
+// addPendingOrder 按订单类型追加到对应队列尾部，保证同类型订单 FIFO。
+func addPendingOrder(vipPending, normalPending *[]Order, order Order) {
+	if order.Type == VIP {
+		*vipPending = append(*vipPending, order)
+		return
+	}
+	*normalPending = append(*normalPending, order)
+}
+
+// popNextOrder 始终先取 VIP 队列；VIP 为空时再取普通队列。
+func popNextOrder(vipPending, normalPending *[]Order) Order {
+	if len(*vipPending) > 0 {
+		order := (*vipPending)[0]
+		*vipPending = (*vipPending)[1:]
+		return order
+	}
+	order := (*normalPending)[0]
+	*normalPending = (*normalPending)[1:]
+	return order
+}
+
+// listPendingOrders 用于快照展示，顺序保持为“所有 VIP pending 在前，普通 pending 在后”。
+func listPendingOrders(vipPending, normalPending []Order) []Order {
+	pending := append([]Order(nil), vipPending...)
+	return append(pending, normalPending...)
+}
+
+func countPendingOrders(vipPending, normalPending []Order) int {
+	return len(vipPending) + len(normalPending)
+}
+
+func firstIdleBot(bots []Bot) *Bot {
+	for i := range bots {
+		if bots[i].Status == BotIdle {
+			return &bots[i]
+		}
+	}
+	return nil
+}
+
+func findBot(bots []Bot, id int) *Bot {
+	for i := range bots {
+		if bots[i].ID == id {
+			return &bots[i]
+		}
+	}
+	return nil
+}
+
+// copyOrder/copyBot 返回副本，避免把 run 内部 slice 元素的指针暴露出去。
+func copyOrder(order Order) *Order {
+	return &order
+}
+
+func copyBot(bot *Bot) *Bot {
+	if bot == nil {
+		return nil
+	}
+	value := *bot
+	return &value
+}
+
+func (c *Controller) log(format string, args ...interface{}) {
+	if c.logWriter == nil {
+		return
+	}
+	fmt.Fprintf(c.logWriter, "[%s] %s\n", time.Now().Format("15:04:05"), fmt.Sprintf(format, args...))
+}
+
+func pendingOrderFromBot(bot Bot) Order {
+	return Order{
+		ID:     bot.CurrentOrderID,
+		Type:   bot.currentType,
+		Status: OrderPending,
+	}
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,12 +1,14 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 )
 
-const processingDuration = 10 * time.Second
+var processingDuration = 10 * time.Second
 
 type OrderType int
 
@@ -25,8 +27,9 @@ func (t OrderType) String() string {
 type OrderStatus string
 
 const (
-	OrderPending  OrderStatus = "PENDING"
-	OrderComplete OrderStatus = "COMPLETE"
+	OrderPending    OrderStatus = "PENDING"
+	OrderProcessing OrderStatus = "PROCESSING"
+	OrderComplete   OrderStatus = "COMPLETE"
 )
 
 type BotStatus string
@@ -43,10 +46,10 @@ type Order struct {
 }
 
 type Bot struct {
-	ID             int
-	Status         BotStatus
-	CurrentOrderID int
-	currentType    OrderType
+	ID            int
+	Status        BotStatus
+	CurrentOrder  *Order
+	cancelCooking context.CancelFunc
 }
 
 type Snapshot struct {
@@ -58,10 +61,14 @@ type Snapshot struct {
 // Controller 通过 commands channel 串行化所有状态变更。
 // pending 队列和 bot 列表只会在 run 这个 goroutine 里读写，因此不需要 mutex。
 type Controller struct {
-	commands  chan command
-	completed chan Order
-	done      chan struct{}
-	logWriter io.Writer
+	commands    chan command
+	done        chan struct{}
+	logWriter   io.Writer
+	pending     []Order
+	completed   []Order
+	bots        []Bot
+	nextOrderID int
+	nextBotID   int
 }
 
 type commandKind int
@@ -91,11 +98,11 @@ type response struct {
 
 func NewController(logWriter io.Writer) *Controller {
 	c := &Controller{
-		commands: make(chan command),
-		// completed 只用于通知外部“有订单完成了”，容量给一点缓冲，避免 CLI 短时间没读取时卡住 controller。
-		completed: make(chan Order, 16),
-		done:      make(chan struct{}),
-		logWriter: logWriter,
+		commands:    make(chan command),
+		done:        make(chan struct{}),
+		logWriter:   logWriter,
+		nextOrderID: 1,
+		nextBotID:   1,
 	}
 	go c.run()
 	return c
@@ -125,11 +132,6 @@ func (c *Controller) Snapshot() Snapshot {
 	return (<-reply).snapshot
 }
 
-// Completed 返回只读 channel，外部可以用它等待订单真正制作完成。
-func (c *Controller) Completed() <-chan Order {
-	return c.completed
-}
-
 func (c *Controller) Stop() {
 	reply := make(chan response)
 	c.commands <- command{kind: cmdStop, reply: reply}
@@ -140,83 +142,87 @@ func (c *Controller) Stop() {
 // run 是 controller 的状态中心。外部 API 和订单制作 goroutine 都只发送命令，
 // 真正修改订单、队列、bot 状态的逻辑都收敛在这里。
 func (c *Controller) run() {
-	var vipPending []Order
-	var normalPending []Order
-	var completed []Order
-	var bots []Bot
-	nextOrderID := 1
-	nextBotID := 1
-
 	for cmd := range c.commands {
 		switch cmd.kind {
 		case cmdNewOrder:
 			order := Order{
-				ID:     nextOrderID,
+				ID:     c.nextOrderID,
 				Type:   cmd.orderTy,
 				Status: OrderPending,
 			}
-			nextOrderID++
-			addPendingOrder(&vipPending, &normalPending, order)
+			c.nextOrderID++
+			c.addPendingOrder(order)
 			c.log("%s Order #%d created - Status: PENDING", order.Type, order.ID)
-			c.dispatchOrders(&vipPending, &normalPending, &bots)
+			c.dispatchOrders()
 			cmd.reply <- response{order: copyOrder(order)}
 
 		case cmdAddBot:
-			bot := Bot{ID: nextBotID, Status: BotIdle}
-			nextBotID++
-			bots = append(bots, bot)
+			bot := Bot{ID: c.nextBotID, Status: BotIdle}
+			c.nextBotID++
+			c.bots = append(c.bots, bot)
 			c.log("Bot #%d created - Status: ACTIVE", bot.ID)
-			c.dispatchOrders(&vipPending, &normalPending, &bots)
-			created := findBot(bots, bot.ID)
+			c.dispatchOrders()
+			created := findBot(c.bots, bot.ID)
 			cmd.reply <- response{bot: copyBot(created)}
 
 		case cmdRemoveBot:
-			if len(bots) == 0 {
+			if len(c.bots) == 0 {
 				cmd.reply <- response{}
 				continue
 			}
 			// 作业要求删除“最后一个 bot”。如果它正在制作订单，需要把订单退回 pending 队列。
-			removed := bots[len(bots)-1]
-			bots = bots[:len(bots)-1]
+			removed := c.bots[len(c.bots)-1]
+			c.bots = c.bots[:len(c.bots)-1]
 			if removed.Status == BotProcessing {
-				order := pendingOrderFromBot(removed)
-				addPendingOrder(&vipPending, &normalPending, order)
-				c.log("Bot #%d destroyed while PROCESSING - %s Order #%d returned to PENDING", removed.ID, order.Type, order.ID)
+				if removed.cancelCooking != nil {
+					removed.cancelCooking()
+				}
+				if removed.CurrentOrder != nil {
+					order := *removed.CurrentOrder
+					order.Status = OrderPending
+					c.addPendingOrder(order)
+					c.log("Bot #%d canceled %s Order #%d", removed.ID, order.Type, order.ID)
+					c.log("Bot #%d destroyed while PROCESSING - %s Order #%d returned to PENDING", removed.ID, order.Type, order.ID)
+				} else {
+					c.log("Bot #%d destroyed while PROCESSING but had no current order", removed.ID)
+				}
 			} else {
 				c.log("Bot #%d destroyed while IDLE", removed.ID)
 			}
 			cmd.reply <- response{bot: copyBot(&removed)}
 
 		case cmdCompleteOrder:
-			bot := findBot(bots, cmd.botID)
-			if bot == nil || bot.Status != BotProcessing || bot.CurrentOrderID != cmd.orderID {
+			bot := findBot(c.bots, cmd.botID)
+			if bot == nil || bot.Status != BotProcessing || bot.CurrentOrder == nil || bot.CurrentOrder.ID != cmd.orderID {
 				continue
 			}
-			order := Order{
-				ID:     cmd.orderID,
-				Type:   bot.currentType,
-				Status: OrderComplete,
-			}
-			completed = append(completed, order)
+			order := *bot.CurrentOrder
+			order.Status = OrderComplete
+			c.completed = append(c.completed, order)
 			c.log("Bot #%d completed %s Order #%d - Status: COMPLETE (Processing time: 10s)", bot.ID, order.Type, order.ID)
-			c.notifyCompleted(order)
 			bot.Status = BotIdle
-			bot.CurrentOrderID = 0
-			c.dispatchOrders(&vipPending, &normalPending, &bots)
+			bot.CurrentOrder = nil
+			bot.cancelCooking = nil
+			c.dispatchOrders()
 			// dispatchOrders 可能会立刻把下一单分配给这个 bot，所以这里要重新检查它是否仍然 idle。
-			if bot.Status == BotIdle && countPendingOrders(vipPending, normalPending) == 0 {
+			if bot.Status == BotIdle && len(c.pending) == 0 {
 				c.log("Bot #%d is now IDLE - No pending orders", bot.ID)
 			}
 
 		case cmdSnapshot:
 			// 返回快照时复制 slice，避免外部拿到内部状态的引用后误改 controller 状态。
 			cmd.reply <- response{snapshot: Snapshot{
-				Pending:   listPendingOrders(vipPending, normalPending),
-				Completed: append([]Order(nil), completed...),
-				Bots:      append([]Bot(nil), bots...),
+				Pending:   append([]Order(nil), c.pending...),
+				Completed: append([]Order(nil), c.completed...),
+				Bots:      copyBots(c.bots),
 			}}
 
 		case cmdStop:
+			for i := range c.bots {
+				if c.bots[i].cancelCooking != nil {
+					c.bots[i].cancelCooking()
+				}
+			}
 			cmd.reply <- response{}
 			return
 		}
@@ -224,26 +230,28 @@ func (c *Controller) run() {
 }
 
 // dispatchOrders 尽可能把 pending 订单派给空闲 bot。
-// 具体优先级由 popNextOrder 决定：VIP 队列优先，其次普通队列。
-func (c *Controller) dispatchOrders(vipPending, normalPending *[]Order, bots *[]Bot) {
-	for countPendingOrders(*vipPending, *normalPending) > 0 {
-		bot := firstIdleBot(*bots)
+// pending 队列已经按优先级排序，因此每次从队首取单即可。
+func (c *Controller) dispatchOrders() {
+	for len(c.pending) > 0 {
+		bot := firstIdleBot(c.bots)
 		if bot == nil {
 			return
 		}
-		order := popNextOrder(vipPending, normalPending)
+		order := c.popNextOrder()
+		order.Status = OrderProcessing
 		bot.Status = BotProcessing
-		bot.CurrentOrderID = order.ID
-		bot.currentType = order.Type
+		bot.CurrentOrder = copyOrder(order)
+		ctx, cancel := context.WithCancel(context.Background())
+		bot.cancelCooking = cancel
 		c.log("Bot #%d picked up %s Order #%d - Status: PROCESSING", bot.ID, order.Type, order.ID)
-		c.makeOrder(bot.ID, order.ID)
+		c.makeOrder(ctx, bot.ID, order.ID)
 	}
 }
 
 // makeOrder 模拟真实的订单制作过程。
 // 制作耗时不放在 run 里等待，否则 controller 就无法继续处理新订单、加 bot、删 bot 等命令。
 // 制作完成后只发回 cmdCompleteOrder，由 run 统一判断这次完成事件是否仍然有效。
-func (c *Controller) makeOrder(botID, orderID int) {
+func (c *Controller) makeOrder(ctx context.Context, botID, orderID int) {
 	go func() {
 		timer := time.NewTimer(processingDuration)
 		defer timer.Stop()
@@ -252,49 +260,40 @@ func (c *Controller) makeOrder(botID, orderID int) {
 			select {
 			case c.commands <- command{kind: cmdCompleteOrder, botID: botID, orderID: orderID}:
 			case <-c.done:
+			case <-ctx.Done():
 			}
+		case <-ctx.Done():
 		case <-c.done:
 		}
 	}()
 }
 
-// notifyCompleted 只负责通知外部有订单完成，不参与 controller 内部状态修改。
-func (c *Controller) notifyCompleted(order Order) {
-	select {
-	case c.completed <- order:
-	case <-c.done:
-	}
+// addPendingOrder 将订单插入单一 pending 队列，保持 VIP 优先，同类型按 ID 升序。
+func (c *Controller) addPendingOrder(order Order) {
+	c.pending = append(c.pending, order)
+	slices.SortStableFunc(c.pending, comparePendingOrders)
 }
 
-// addPendingOrder 按订单类型追加到对应队列尾部，保证同类型订单 FIFO。
-func addPendingOrder(vipPending, normalPending *[]Order, order Order) {
-	if order.Type == VIP {
-		*vipPending = append(*vipPending, order)
-		return
+func comparePendingOrders(a, b Order) int {
+	if a.Type != b.Type {
+		if a.Type == VIP {
+			return -1
+		}
+		return 1
 	}
-	*normalPending = append(*normalPending, order)
+	if a.ID < b.ID {
+		return -1
+	}
+	if a.ID > b.ID {
+		return 1
+	}
+	return 0
 }
 
-// popNextOrder 始终先取 VIP 队列；VIP 为空时再取普通队列。
-func popNextOrder(vipPending, normalPending *[]Order) Order {
-	if len(*vipPending) > 0 {
-		order := (*vipPending)[0]
-		*vipPending = (*vipPending)[1:]
-		return order
-	}
-	order := (*normalPending)[0]
-	*normalPending = (*normalPending)[1:]
+func (c *Controller) popNextOrder() Order {
+	order := c.pending[0]
+	c.pending = c.pending[1:]
 	return order
-}
-
-// listPendingOrders 用于快照展示，顺序保持为“所有 VIP pending 在前，普通 pending 在后”。
-func listPendingOrders(vipPending, normalPending []Order) []Order {
-	pending := append([]Order(nil), vipPending...)
-	return append(pending, normalPending...)
-}
-
-func countPendingOrders(vipPending, normalPending []Order) int {
-	return len(vipPending) + len(normalPending)
 }
 
 func firstIdleBot(bots []Bot) *Bot {
@@ -325,7 +324,18 @@ func copyBot(bot *Bot) *Bot {
 		return nil
 	}
 	value := *bot
+	if bot.CurrentOrder != nil {
+		value.CurrentOrder = copyOrder(*bot.CurrentOrder)
+	}
 	return &value
+}
+
+func copyBots(bots []Bot) []Bot {
+	copied := make([]Bot, len(bots))
+	for i := range bots {
+		copied[i] = *copyBot(&bots[i])
+	}
+	return copied
 }
 
 func (c *Controller) log(format string, args ...interface{}) {
@@ -333,12 +343,4 @@ func (c *Controller) log(format string, args ...interface{}) {
 		return
 	}
 	fmt.Fprintf(c.logWriter, "[%s] %s\n", time.Now().Format("15:04:05"), fmt.Sprintf(format, args...))
-}
-
-func pendingOrderFromBot(bot Bot) Order {
-	return Order{
-		ID:     bot.CurrentOrderID,
-		Type:   bot.currentType,
-		Status: OrderPending,
-	}
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,176 @@
+package controller
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVIPOrdersAreDispatchedBeforeNormalOrders(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	normal := c.NewOrder(Normal)
+	vip := c.NewOrder(VIP)
+	bot := c.AddBot()
+
+	snapshot := c.Snapshot()
+	if bot.CurrentOrderID != vip.ID {
+		t.Fatalf("bot picked order %d, want VIP order %d", bot.CurrentOrderID, vip.ID)
+	}
+	if len(snapshot.Pending) != 1 || snapshot.Pending[0].ID != normal.ID {
+		t.Fatalf("pending queue = %+v, want only normal order %d", snapshot.Pending, normal.ID)
+	}
+}
+
+func TestPendingOrdersKeepVIPPriorityAndFIFO(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	normal1 := c.NewOrder(Normal)
+	vip1 := c.NewOrder(VIP)
+	normal2 := c.NewOrder(Normal)
+	vip2 := c.NewOrder(VIP)
+
+	snapshot := c.Snapshot()
+	expected := []int{vip1.ID, vip2.ID, normal1.ID, normal2.ID}
+	if len(snapshot.Pending) != len(expected) {
+		t.Fatalf("pending = %+v, want %d orders", snapshot.Pending, len(expected))
+	}
+	for i, orderID := range expected {
+		if snapshot.Pending[i].ID != orderID {
+			t.Fatalf("pending[%d] = order %d, want order %d; pending = %+v", i, snapshot.Pending[i].ID, orderID, snapshot.Pending)
+		}
+	}
+}
+
+func TestRemovingProcessingBotReturnsOrderToPriorityQueue(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	normal := c.NewOrder(Normal)
+	c.AddBot()
+	vip := c.NewOrder(VIP)
+
+	removed := c.RemoveBot()
+	if removed == nil {
+		t.Fatal("expected a bot to be removed")
+	}
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Bots) != 0 {
+		t.Fatalf("bots = %+v, want no active bots", snapshot.Bots)
+	}
+	if len(snapshot.Pending) != 2 {
+		t.Fatalf("pending count = %d, want 2", len(snapshot.Pending))
+	}
+	if snapshot.Pending[0].ID != vip.ID || snapshot.Pending[1].ID != normal.ID {
+		t.Fatalf("pending order = %+v, want VIP %d before returned normal %d", snapshot.Pending, vip.ID, normal.ID)
+	}
+}
+
+func TestRemoveBotRemovesNewestBot(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	first := c.AddBot()
+	second := c.AddBot()
+
+	removed := c.RemoveBot()
+	if removed == nil || removed.ID != second.ID {
+		t.Fatalf("removed bot = %+v, want newest bot %d", removed, second.ID)
+	}
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Bots) != 1 || snapshot.Bots[0].ID != first.ID {
+		t.Fatalf("bots = %+v, want only bot %d remaining", snapshot.Bots, first.ID)
+	}
+}
+
+func TestCompletionCommandFromRemovedBotIsIgnored(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	order := c.NewOrder(Normal)
+	c.AddBot()
+	c.RemoveBot()
+	sendComplete(c, 1, order.ID)
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Completed) != 0 {
+		t.Fatalf("completed = %+v, want no completed orders after removed bot timer fires", snapshot.Completed)
+	}
+	if len(snapshot.Pending) != 1 || snapshot.Pending[0].ID != order.ID {
+		t.Fatalf("pending = %+v, want returned order %d", snapshot.Pending, order.ID)
+	}
+}
+
+func TestBotCompletesOrderAndContinuesWithNextPriorityOrder(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	normal := c.NewOrder(Normal)
+	vip := c.NewOrder(VIP)
+	c.AddBot()
+
+	sendComplete(c, 1, vip.ID)
+	sendComplete(c, 1, normal.ID)
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Completed) != 2 {
+		t.Fatalf("completed count = %d, want 2", len(snapshot.Completed))
+	}
+	if snapshot.Completed[0].ID != vip.ID || snapshot.Completed[1].ID != normal.ID {
+		t.Fatalf("completed = %+v, want VIP %d then normal %d", snapshot.Completed, vip.ID, normal.ID)
+	}
+	if len(snapshot.Pending) != 0 {
+		t.Fatalf("pending = %+v, want empty", snapshot.Pending)
+	}
+	if len(snapshot.Bots) != 1 || snapshot.Bots[0].Status != BotIdle {
+		t.Fatalf("bots = %+v, want one idle bot", snapshot.Bots)
+	}
+}
+
+func TestCompletedChannelReceivesCompletedOrders(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	order := c.NewOrder(Normal)
+	c.AddBot()
+	sendComplete(c, 1, order.ID)
+
+	select {
+	case completed := <-c.Completed():
+		if completed.ID != order.ID {
+			t.Fatalf("completed order ID = %d, want %d", completed.ID, order.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completed order event")
+	}
+}
+
+func TestBotIsNotLoggedIdleWhenItImmediatelyReceivesAnotherOrder(t *testing.T) {
+	var log bytes.Buffer
+	c := NewController(&log)
+	defer c.Stop()
+
+	normal := c.NewOrder(Normal)
+	vip := c.NewOrder(VIP)
+	c.AddBot()
+
+	sendComplete(c, 1, vip.ID)
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Bots) != 1 || snapshot.Bots[0].Status != BotProcessing || snapshot.Bots[0].CurrentOrderID != normal.ID {
+		t.Fatalf("bot state = %+v, want processing normal order %d", snapshot.Bots, normal.ID)
+	}
+	if strings.Contains(log.String(), "Bot #1 is now IDLE") {
+		t.Fatalf("bot was logged idle while it had another order; logs:\n%s", log.String())
+	}
+}
+
+func sendComplete(c *Controller, botID, orderID int) {
+	c.commands <- command{kind: cmdCompleteOrder, botID: botID, orderID: orderID}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -17,11 +18,70 @@ func TestVIPOrdersAreDispatchedBeforeNormalOrders(t *testing.T) {
 	bot := c.AddBot()
 
 	snapshot := c.Snapshot()
-	if bot.CurrentOrderID != vip.ID {
-		t.Fatalf("bot picked order %d, want VIP order %d", bot.CurrentOrderID, vip.ID)
+	if bot.CurrentOrder == nil || bot.CurrentOrder.ID != vip.ID {
+		t.Fatalf("bot current order = %+v, want VIP order %d", bot.CurrentOrder, vip.ID)
 	}
 	if len(snapshot.Pending) != 1 || snapshot.Pending[0].ID != normal.ID {
 		t.Fatalf("pending queue = %+v, want only normal order %d", snapshot.Pending, normal.ID)
+	}
+}
+
+func TestOrderStatusChangesToProcessingWhenBotPicksOrder(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	order := c.NewOrder(Normal)
+	c.AddBot()
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Bots) != 1 || snapshot.Bots[0].CurrentOrder == nil {
+		t.Fatalf("bots = %+v, want one bot with current order", snapshot.Bots)
+	}
+	if snapshot.Bots[0].CurrentOrder.ID != order.ID {
+		t.Fatalf("current order ID = %d, want %d", snapshot.Bots[0].CurrentOrder.ID, order.ID)
+	}
+	if snapshot.Bots[0].CurrentOrder.Status != OrderProcessing {
+		t.Fatalf("current order status = %s, want %s", snapshot.Bots[0].CurrentOrder.Status, OrderProcessing)
+	}
+}
+
+func TestSnapshotDoesNotExposeInternalCurrentOrderPointer(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	order := c.NewOrder(Normal)
+	c.AddBot()
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Bots) != 1 || snapshot.Bots[0].CurrentOrder == nil {
+		t.Fatalf("snapshot bots = %+v, want bot with current order", snapshot.Bots)
+	}
+	snapshot.Bots[0].CurrentOrder.ID = 999
+	snapshot.Bots[0].CurrentOrder.Status = OrderComplete
+
+	nextSnapshot := c.Snapshot()
+	if nextSnapshot.Bots[0].CurrentOrder.ID != order.ID {
+		t.Fatalf("current order ID = %d, want %d", nextSnapshot.Bots[0].CurrentOrder.ID, order.ID)
+	}
+	if nextSnapshot.Bots[0].CurrentOrder.Status != OrderProcessing {
+		t.Fatalf("current order status = %s, want %s", nextSnapshot.Bots[0].CurrentOrder.Status, OrderProcessing)
+	}
+}
+
+func TestProcessingOrderReturnsToPendingStatusWhenBotIsRemoved(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	order := c.NewOrder(Normal)
+	c.AddBot()
+	c.RemoveBot()
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Pending) != 1 || snapshot.Pending[0].ID != order.ID {
+		t.Fatalf("pending = %+v, want returned order %d", snapshot.Pending, order.ID)
+	}
+	if snapshot.Pending[0].Status != OrderPending {
+		t.Fatalf("returned order status = %s, want %s", snapshot.Pending[0].Status, OrderPending)
 	}
 }
 
@@ -68,6 +128,58 @@ func TestRemovingProcessingBotReturnsOrderToPriorityQueue(t *testing.T) {
 	}
 	if snapshot.Pending[0].ID != vip.ID || snapshot.Pending[1].ID != normal.ID {
 		t.Fatalf("pending order = %+v, want VIP %d before returned normal %d", snapshot.Pending, vip.ID, normal.ID)
+	}
+}
+
+func TestRemovingProcessingBotReinsertsOrderByIDWithinSamePriorityQueue(t *testing.T) {
+	c := NewController(io.Discard)
+	defer c.Stop()
+
+	first := c.NewOrder(Normal)
+	second := c.NewOrder(Normal)
+	c.AddBot()
+
+	removed := c.RemoveBot()
+	if removed == nil {
+		t.Fatal("expected a bot to be removed")
+	}
+
+	snapshot := c.Snapshot()
+	if len(snapshot.Pending) != 2 {
+		t.Fatalf("pending count = %d, want 2", len(snapshot.Pending))
+	}
+	if snapshot.Pending[0].ID != first.ID || snapshot.Pending[1].ID != second.ID {
+		t.Fatalf("pending order = %+v, want returned order %d before order %d", snapshot.Pending, first.ID, second.ID)
+	}
+}
+
+func TestRemovingProcessingBotCancelsCookingImmediately(t *testing.T) {
+	originalDuration := processingDuration
+	processingDuration = time.Second
+	defer func() {
+		processingDuration = originalDuration
+	}()
+
+	var log bytes.Buffer
+	c := NewController(&log)
+	defer c.Stop()
+
+	order := c.NewOrder(Normal)
+	c.AddBot()
+	c.RemoveBot()
+
+	expectedLog := fmt.Sprintf("canceled Normal Order #%d", order.ID)
+	deadline := time.After(200 * time.Millisecond)
+	for {
+		if strings.Contains(log.String(), expectedLog) {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for cooking cancellation for order %d; logs:\n%s", order.ID, log.String())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 }
 
@@ -125,29 +237,16 @@ func TestBotCompletesOrderAndContinuesWithNextPriorityOrder(t *testing.T) {
 	if snapshot.Completed[0].ID != vip.ID || snapshot.Completed[1].ID != normal.ID {
 		t.Fatalf("completed = %+v, want VIP %d then normal %d", snapshot.Completed, vip.ID, normal.ID)
 	}
+	for _, order := range snapshot.Completed {
+		if order.Status != OrderComplete {
+			t.Fatalf("completed order = %+v, want COMPLETE status", order)
+		}
+	}
 	if len(snapshot.Pending) != 0 {
 		t.Fatalf("pending = %+v, want empty", snapshot.Pending)
 	}
 	if len(snapshot.Bots) != 1 || snapshot.Bots[0].Status != BotIdle {
 		t.Fatalf("bots = %+v, want one idle bot", snapshot.Bots)
-	}
-}
-
-func TestCompletedChannelReceivesCompletedOrders(t *testing.T) {
-	c := NewController(io.Discard)
-	defer c.Stop()
-
-	order := c.NewOrder(Normal)
-	c.AddBot()
-	sendComplete(c, 1, order.ID)
-
-	select {
-	case completed := <-c.Completed():
-		if completed.ID != order.ID {
-			t.Fatalf("completed order ID = %d, want %d", completed.ID, order.ID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for completed order event")
 	}
 }
 
@@ -163,7 +262,7 @@ func TestBotIsNotLoggedIdleWhenItImmediatelyReceivesAnotherOrder(t *testing.T) {
 	sendComplete(c, 1, vip.ID)
 
 	snapshot := c.Snapshot()
-	if len(snapshot.Bots) != 1 || snapshot.Bots[0].Status != BotProcessing || snapshot.Bots[0].CurrentOrderID != normal.ID {
+	if len(snapshot.Bots) != 1 || snapshot.Bots[0].Status != BotProcessing || snapshot.Bots[0].CurrentOrder == nil || snapshot.Bots[0].CurrentOrder.ID != normal.ID {
 		t.Fatalf("bot state = %+v, want processing normal order %d", snapshot.Bots, normal.ID)
 	}
 	if strings.Contains(log.String(), "Bot #1 is now IDLE") {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
+set -euo pipefail
 
-# Build Script
-# This script should contain all compilation steps for your CLI application
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
 
 echo "Building CLI application..."
 
-# For Go projects:
-# go build -o order-controller ./cmd/main.go
-
-# For Node.js projects:
-# npm install
-# npm run build (if needed)
+go build -o order-controller ./cmd
 
 echo "Build completed"

--- a/scripts/result.txt
+++ b/scripts/result.txt
@@ -1,26 +1,28 @@
-McDonald's Order Management System - Simulation Results
-
-[14:32:01] System initialized with 0 bots
-[14:32:01] Created Normal Order #1001 - Status: PENDING
-[14:32:02] Created VIP Order #1002 - Status: PENDING
-[14:32:02] Created Normal Order #1003 - Status: PENDING
-[14:32:03] Bot #1 created - Status: ACTIVE
-[14:32:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
-[14:32:04] Bot #2 created - Status: ACTIVE
-[14:32:04] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
-[14:32:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
-[14:32:13] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
-[14:32:14] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
-[14:32:14] Bot #2 is now IDLE - No pending orders
-[14:32:15] Created VIP Order #1004 - Status: PENDING
-[14:32:15] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
-[14:32:23] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 destroyed while IDLE
-[14:32:26] Bot #1 is now IDLE - No pending orders
+McDonald's Order Management System - CLI Simulation
+[17:51:28] System initialized with 0 bots
+[17:51:28] Normal Order #1 created - Status: PENDING
+[17:51:28] Normal Order #2 created - Status: PENDING
+[17:51:28] VIP Order #3 created - Status: PENDING
+[17:51:28] Normal Order #4 created - Status: PENDING
+[17:51:29] Bot #1 created - Status: ACTIVE
+[17:51:29] Bot #1 picked up VIP Order #3 - Status: PROCESSING
+[17:51:30] Bot #2 created - Status: ACTIVE
+[17:51:30] Bot #2 picked up Normal Order #1 - Status: PROCESSING
+[17:51:39] Bot #1 completed VIP Order #3 - Status: COMPLETE (Processing time: 10s)
+[17:51:39] Bot #1 picked up Normal Order #2 - Status: PROCESSING
+[17:51:40] Bot #2 completed Normal Order #1 - Status: COMPLETE (Processing time: 10s)
+[17:51:40] Bot #2 picked up Normal Order #4 - Status: PROCESSING
+[17:51:42] VIP Order #5 created - Status: PENDING
+[17:51:43] Bot #2 destroyed while PROCESSING - Normal Order #4 returned to PENDING
+[17:51:49] Bot #1 completed Normal Order #2 - Status: COMPLETE (Processing time: 10s)
+[17:51:49] Bot #1 picked up VIP Order #5 - Status: PROCESSING
+[17:51:59] Bot #1 completed VIP Order #5 - Status: COMPLETE (Processing time: 10s)
+[17:51:59] Bot #1 picked up Normal Order #4 - Status: PROCESSING
+[17:52:09] Bot #1 completed Normal Order #4 - Status: COMPLETE (Processing time: 10s)
+[17:52:09] Bot #1 is now IDLE - No pending orders
 
 Final Status:
-- Total Orders Processed: 4 (2 VIP, 2 Normal)
-- Orders Completed: 4
+- Total Orders Processed: 5 (2 VIP, 3 Normal)
+- Orders Completed: 5
 - Active Bots: 1
 - Pending Orders: 0

--- a/scripts/result.txt
+++ b/scripts/result.txt
@@ -1,28 +1,19 @@
 McDonald's Order Management System - CLI Simulation
-[17:51:28] System initialized with 0 bots
-[17:51:28] Normal Order #1 created - Status: PENDING
-[17:51:28] Normal Order #2 created - Status: PENDING
-[17:51:28] VIP Order #3 created - Status: PENDING
-[17:51:28] Normal Order #4 created - Status: PENDING
-[17:51:29] Bot #1 created - Status: ACTIVE
-[17:51:29] Bot #1 picked up VIP Order #3 - Status: PROCESSING
-[17:51:30] Bot #2 created - Status: ACTIVE
-[17:51:30] Bot #2 picked up Normal Order #1 - Status: PROCESSING
-[17:51:39] Bot #1 completed VIP Order #3 - Status: COMPLETE (Processing time: 10s)
-[17:51:39] Bot #1 picked up Normal Order #2 - Status: PROCESSING
-[17:51:40] Bot #2 completed Normal Order #1 - Status: COMPLETE (Processing time: 10s)
-[17:51:40] Bot #2 picked up Normal Order #4 - Status: PROCESSING
-[17:51:42] VIP Order #5 created - Status: PENDING
-[17:51:43] Bot #2 destroyed while PROCESSING - Normal Order #4 returned to PENDING
-[17:51:49] Bot #1 completed Normal Order #2 - Status: COMPLETE (Processing time: 10s)
-[17:51:49] Bot #1 picked up VIP Order #5 - Status: PROCESSING
-[17:51:59] Bot #1 completed VIP Order #5 - Status: COMPLETE (Processing time: 10s)
-[17:51:59] Bot #1 picked up Normal Order #4 - Status: PROCESSING
-[17:52:09] Bot #1 completed Normal Order #4 - Status: COMPLETE (Processing time: 10s)
-[17:52:09] Bot #1 is now IDLE - No pending orders
-
-Final Status:
-- Total Orders Processed: 5 (2 VIP, 3 Normal)
-- Orders Completed: 5
-- Active Bots: 1
-- Pending Orders: 0
+[11:19:12] System initialized with 0 bots
+[11:19:12] Normal Order #1 created - Status: PENDING
+[11:19:12] Normal Order #2 created - Status: PENDING
+[11:19:12] VIP Order #3 created - Status: PENDING
+[11:19:12] Normal Order #4 created - Status: PENDING
+[11:19:13] Bot #1 created - Status: ACTIVE
+[11:19:13] Bot #1 picked up VIP Order #3 - Status: PROCESSING
+[11:19:14] Bot #2 created - Status: ACTIVE
+[11:19:14] Bot #2 picked up Normal Order #1 - Status: PROCESSING
+[11:19:23] Bot #1 completed VIP Order #3 - Status: COMPLETE (Processing time: 10s)
+[11:19:23] Bot #1 picked up Normal Order #2 - Status: PROCESSING
+[11:19:24] Bot #2 completed Normal Order #1 - Status: COMPLETE (Processing time: 10s)
+[11:19:24] Bot #2 picked up Normal Order #4 - Status: PROCESSING
+[11:19:26] VIP Order #5 created - Status: PENDING
+[11:19:27] Bot #2 canceled Normal Order #4
+[11:19:27] Bot #2 destroyed while PROCESSING - Normal Order #4 returned to PENDING
+[11:19:33] Bot #1 completed Normal Order #2 - Status: COMPLETE (Processing time: 10s)
+[11:19:33] Bot #1 picked up VIP Order #5 - Status: PROCESSING

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,6 +6,6 @@ cd "$ROOT_DIR"
 
 echo "Running CLI application..."
 
-./order-controller > scripts/result.txt
+./order-controller --simulate > scripts/result.txt
 
 echo "CLI application execution completed"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
+set -euo pipefail
 
-# Run Script
-# This script should execute your CLI application and output results to result.txt
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
 
 echo "Running CLI application..."
 
-# For Go projects:
-# ./order-controller > result.txt
-
-# For Node.js projects:
-# node index.js > result.txt
-# or npm start > result.txt
-
-# Temporary placeholder - remove this when you implement your CLI
-echo "Added 1 bot" > result.txt
-echo "status: bot: [1], order: []" >> result.txt
+./order-controller > scripts/result.txt
 
 echo "CLI application execution completed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
+set -euo pipefail
 
-# Unit Test Script
-# This script should contain all unit test execution steps
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
 
 echo "Running unit tests..."
 
-# For Go projects:
-# go test ./... -v
-
-# For Node.js projects:
-# npm test
+go test ./... -v
 
 echo "Unit tests completed"


### PR DESCRIPTION
## 实现内容

- 使用 Go 实现 CLI 版订单控制器
- 支持普通订单和 VIP 订单，VIP 优先且同类型保持 FIFO
- 支持新增/删除 bot，删除正在处理订单的 bot 时订单会回到 pending 队列
- 使用单 goroutine coordinator 统一处理状态变更，避免并发读写冲突
- 补充单元测试，并完善 test/build/run 脚本

## 验证方式

- ./scripts/test.sh
- ./scripts/build.sh
- ./scripts/run.sh