### PR TITLE
Implement order controller (Node.js + TypeScript CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "mcd-order-controller",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcd-order-controller",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mcd-order-controller",
+  "version": "1.0.0",
+  "description": "McDonald's automated cooking-bot order controller (Node.js + TypeScript CLI)",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node --test \"dist/**/*.test.js\"",
+    "start": "node dist/index.js",
+    "cli": "node dist/cli.js"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@ echo "Building CLI application..."
 # go build -o order-controller ./cmd/main.go
 
 # For Node.js projects:
-# npm install
-# npm run build (if needed)
+npm install
+npm run build 
 
 echo "Build completed"

--- a/scripts/result.txt
+++ b/scripts/result.txt
@@ -1,26 +1,33 @@
-McDonald's Order Management System - Simulation Results
 
-[14:32:01] System initialized with 0 bots
-[14:32:01] Created Normal Order #1001 - Status: PENDING
-[14:32:02] Created VIP Order #1002 - Status: PENDING
-[14:32:02] Created Normal Order #1003 - Status: PENDING
-[14:32:03] Bot #1 created - Status: ACTIVE
-[14:32:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
-[14:32:04] Bot #2 created - Status: ACTIVE
-[14:32:04] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
-[14:32:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
-[14:32:13] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
-[14:32:14] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
-[14:32:14] Bot #2 is now IDLE - No pending orders
-[14:32:15] Created VIP Order #1004 - Status: PENDING
-[14:32:15] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
-[14:32:23] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 destroyed while IDLE
-[14:32:26] Bot #1 is now IDLE - No pending orders
+> mcd-order-controller@1.0.0 start
+> node dist/index.js
+
+[00:16:55] System initialized with 0 bots
+[00:16:55] Created Normal Order #1001 - Status: PENDING
+[00:16:55] Created Normal Order #1002 - Status: PENDING
+[00:16:55] Created VIP Order #1003 - Status: PENDING
+[00:16:55] Created VIP Order #1004 - Status: PENDING
+[00:16:55] Created Normal Order #1005 - Status: PENDING
+[00:16:55] Bot #1 created - Status: ACTIVE
+[00:16:55] Bot #1 picked up VIP Order #1003 - Status: PROCESSING
+[00:16:55] Bot #2 created - Status: ACTIVE
+[00:16:55] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
+[00:16:58] Bot #2 destroyed - returned VIP Order #1004 to PENDING
+[00:16:59] Bot #3 created - Status: ACTIVE
+[00:16:59] Bot #3 picked up VIP Order #1004 - Status: PROCESSING
+[00:17:05] Bot #1 completed VIP Order #1003 - Status: COMPLETE (Processing time: 10s)
+[00:17:05] Bot #1 picked up Normal Order #1001 - Status: PROCESSING
+[00:17:09] Bot #3 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
+[00:17:09] Bot #3 picked up Normal Order #1002 - Status: PROCESSING
+[00:17:15] Bot #1 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
+[00:17:15] Bot #1 picked up Normal Order #1005 - Status: PROCESSING
+[00:17:19] Bot #3 completed Normal Order #1002 - Status: COMPLETE (Processing time: 10s)
+[00:17:19] Bot #3 is now IDLE - No pending orders
+[00:17:25] Bot #1 completed Normal Order #1005 - Status: COMPLETE (Processing time: 10s)
+[00:17:25] Bot #1 is now IDLE - No pending orders
 
 Final Status:
-- Total Orders Processed: 4 (2 VIP, 2 Normal)
-- Orders Completed: 4
-- Active Bots: 1
+- Total Orders Processed: 5 (2 VIP, 3 Normal)
+- Orders Completed: 5
+- Active Bots: 2
 - Pending Orders: 0

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,10 +10,10 @@ echo "Running CLI application..."
 
 # For Node.js projects:
 # node index.js > result.txt
-# or npm start > result.txt
+npm start > scripts/result.txt
 
-# Temporary placeholder - remove this when you implement your CLI
-echo "Added 1 bot" > result.txt
-echo "status: bot: [1], order: []" >> result.txt
+# # Temporary placeholder - remove this when you implement your CLI
+# echo "Added 1 bot" > result.txt
+# echo "status: bot: [1], order: []" >> result.txt
 
 echo "CLI application execution completed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,6 @@ echo "Running unit tests..."
 # go test ./... -v
 
 # For Node.js projects:
-# npm test
+npm test
 
 echo "Unit tests completed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,8 @@ echo "Running unit tests..."
 # go test ./... -v
 
 # For Node.js projects:
-npm test
+npm install
+npm run build
+node --test "dist/**/*.test.js"
 
 echo "Unit tests completed"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,67 @@
+import readline from 'node:readline';
+import { OrderController } from './order-controller.js';
+import { createPrinter, timestamp } from './format.js';
+
+const controller = new OrderController({ processingMs: 10_000 });
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: '> ' });
+
+controller.on((event) => {
+  createPrinter((line) => {
+    process.stdout.write(`\r${line}\n`);
+  })(event);
+  rl.prompt(true);
+});
+
+function printHelp(): void {
+  console.log('Commands: normal | vip | addbot | removebot | status | help | exit');
+}
+
+function printStatus(): void {
+  const pending = controller.pending.map((o) => `${o.type} #${o.id}`).join(', ') || '(none)';
+  const processing = controller.bots
+    .filter((b) => b.currentOrder)
+    .map((b) => `Bot#${b.id}->${b.currentOrder!.type} #${b.currentOrder!.id}`)
+    .join(', ') || '(none)';
+  const completed = controller.completed.map((o) => `#${o.id}`).join(', ') || '(none)';
+  console.log(`[${timestamp()}] PENDING: ${pending}`);
+  console.log(`[${timestamp()}] PROCESSING: ${processing}`);
+  console.log(`[${timestamp()}] COMPLETE: ${completed}`);
+}
+
+console.log("McDonald's Order Controller — interactive CLI");
+printHelp();
+rl.prompt();
+
+rl.on('line', (line) => {
+  switch (line.trim().toLowerCase()) {
+    case 'normal':
+      controller.newOrder('NORMAL');
+      break;
+    case 'vip':
+      controller.newOrder('VIP');
+      break;
+    case 'addbot':
+      controller.addBot();
+      break;
+    case 'removebot':
+      controller.removeBot();
+      break;
+    case 'status':
+      printStatus();
+      break;
+    case 'help':
+      printHelp();
+      break;
+    case 'exit':
+    case 'quit':
+      rl.close();
+      return;
+    case '':
+      break;
+    default:
+      console.log(`Unknown command: "${line.trim()}" (type "help")`);
+  }
+  rl.prompt();
+});
+
+rl.on('close', () => process.exit(0));

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,36 @@
+import type { ControllerEvent, Order } from './order-controller.js';
+
+export function timestamp(date: Date = new Date()): string {
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  const ss = String(date.getSeconds()).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}
+
+const label = (o: Order): string => `${o.type === 'VIP' ? 'VIP' : 'Normal'} Order #${o.id}`;
+
+export function formatEvent(event: ControllerEvent, processingSeconds = 10): string {
+  switch (event.type) {
+    case 'ORDER_CREATED':
+      return `Created ${label(event.order)} - Status: PENDING`;
+    case 'BOT_CREATED':
+      return `Bot #${event.bot.id} created - Status: ACTIVE`;
+    case 'BOT_PICKED':
+      return `Bot #${event.bot.id} picked up ${label(event.order)} - Status: PROCESSING`;
+    case 'ORDER_COMPLETED':
+      return `Bot #${event.bot.id} completed ${label(event.order)} - Status: COMPLETE (Processing time: ${processingSeconds}s)`;
+    case 'BOT_IDLE':
+      return `Bot #${event.bot.id} is now IDLE - No pending orders`;
+    case 'BOT_DESTROYED':
+      return event.returnedOrder
+        ? `Bot #${event.bot.id} destroyed - returned ${label(event.returnedOrder)} to PENDING`
+        : `Bot #${event.bot.id} destroyed while IDLE`;
+  }
+}
+
+export function createPrinter(
+  out: (line: string) => void,
+  processingSeconds = 10,
+): (event: ControllerEvent) => void {
+  return (event) => out(`[${timestamp()}] ${formatEvent(event, processingSeconds)}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,58 @@
+import { OrderController } from './order-controller.js';
+import { createPrinter, timestamp } from './format.js';
+
+const PROCESSING_MS = 10_000;
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+function printSummary(controller: OrderController): void {
+  const vip = controller.completed.filter((o) => o.type === 'VIP').length;
+  const normal = controller.completed.filter((o) => o.type === 'NORMAL').length;
+  console.log('');
+  console.log('Final Status:');
+  console.log(`- Total Orders Processed: ${controller.completed.length} (${vip} VIP, ${normal} Normal)`);
+  console.log(`- Orders Completed: ${controller.completed.length}`);
+  console.log(`- Active Bots: ${controller.bots.length}`);
+  console.log(`- Pending Orders: ${controller.pending.length}`);
+}
+
+function waitUntilDrained(controller: OrderController): Promise<void> {
+  return new Promise((resolve) => {
+    controller.on((event) => {
+      if (
+        (event.type === 'ORDER_COMPLETED' || event.type === 'BOT_IDLE') &&
+        controller.isDrained()
+      ) {
+        resolve();
+      }
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const controller = new OrderController({ processingMs: PROCESSING_MS });
+  controller.on(createPrinter((line) => console.log(line), PROCESSING_MS / 1000));
+
+  console.log(`[${timestamp()}] System initialized with 0 bots`);
+
+  controller.newOrder('NORMAL'); 
+  controller.newOrder('NORMAL'); 
+  controller.newOrder('VIP'); 
+  controller.newOrder('VIP'); 
+  controller.newOrder('NORMAL'); 
+
+  controller.addBot(); 
+  controller.addBot(); 
+
+  const drained = waitUntilDrained(controller);
+
+  await sleep(3000);
+  controller.removeBot(); 
+
+  await sleep(1000);
+  controller.addBot(); 
+
+  await drained;
+  printSummary(controller);
+}
+
+main();

--- a/src/order-controller.test.ts
+++ b/src/order-controller.test.ts
@@ -1,0 +1,145 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OrderController, type TimerHandle } from './order-controller.js';
+
+// Controllable stand-in for setTimeout/clearTimeout so tests are instant and
+// deterministic: completions only happen when the test calls flushAll().
+class FakeScheduler {
+  private queue: { id: number; cb: () => void }[] = [];
+  private counter = 0;
+
+  setTimeoutFn = (cb: () => void): TimerHandle => {
+    const id = ++this.counter;
+    this.queue.push({ id, cb });
+    return id as unknown as TimerHandle;
+  };
+
+  clearTimeoutFn = (handle: TimerHandle): void => {
+    const id = handle as unknown as number;
+    this.queue = this.queue.filter((t) => t.id !== id);
+  };
+
+  private flushOnce(): void {
+    const current = this.queue;
+    this.queue = [];
+    for (const t of current) t.cb();
+  }
+
+  flushAll(): void {
+    let guard = 0;
+    while (this.queue.length > 0 && guard++ < 1000) this.flushOnce();
+  }
+
+  get pendingTimers(): number {
+    return this.queue.length;
+  }
+}
+
+function makeController() {
+  const scheduler = new FakeScheduler();
+  const controller = new OrderController({
+    processingMs: 10_000,
+    setTimeoutFn: scheduler.setTimeoutFn,
+    clearTimeoutFn: scheduler.clearTimeoutFn,
+  });
+  return { controller, scheduler };
+}
+
+const pendingIds = (c: OrderController) => c.pending.map((o) => o.id);
+const completedIds = (c: OrderController) => c.completed.map((o) => o.id);
+
+test('order ids are unique and strictly increasing', () => {
+  const { controller } = makeController();
+  const a = controller.newOrder('NORMAL');
+  const b = controller.newOrder('VIP');
+  const c = controller.newOrder('NORMAL');
+  assert.deepEqual([a.id, b.id, c.id], [1001, 1002, 1003]);
+});
+
+test('VIP queues ahead of Normals but behind existing VIPs (FIFO within tier)', () => {
+  const { controller } = makeController();
+  controller.newOrder('NORMAL'); // #1001
+  controller.newOrder('NORMAL'); // #1002
+  controller.newOrder('VIP'); //    #1003
+  controller.newOrder('VIP'); //    #1004
+  controller.newOrder('NORMAL'); // #1005
+  assert.deepEqual(pendingIds(controller), [1003, 1004, 1001, 1002, 1005]);
+});
+
+test('a bot picks up and completes an order after processing', () => {
+  const { controller, scheduler } = makeController();
+  controller.addBot();
+  controller.newOrder('NORMAL');
+  assert.equal(controller.pending.length, 0);
+  assert.equal(controller.bots[0].status, 'PROCESSING');
+
+  scheduler.flushAll();
+  assert.deepEqual(completedIds(controller), [1001]);
+  assert.equal(controller.bots[0].status, 'IDLE');
+  assert.equal(controller.completed[0].status, 'COMPLETE');
+});
+
+test('adding a bot when orders are pending starts processing immediately', () => {
+  const { controller } = makeController();
+  controller.newOrder('VIP'); //    #1001
+  controller.newOrder('NORMAL'); // #1002
+  assert.deepEqual(pendingIds(controller), [1001, 1002]);
+
+  controller.addBot();
+  assert.equal(controller.bots[0].currentOrder?.id, 1001);
+  assert.deepEqual(pendingIds(controller), [1002]);
+});
+
+test('with no pending orders a bot stays idle, then wakes on a new order', () => {
+  const { controller } = makeController();
+  controller.addBot();
+  assert.equal(controller.bots[0].status, 'IDLE');
+
+  controller.newOrder('NORMAL');
+  assert.equal(controller.bots[0].status, 'PROCESSING');
+  assert.equal(controller.bots[0].currentOrder?.id, 1001);
+});
+
+test('removing a bot mid-process cancels the timer and requeues by priority', () => {
+  const { controller, scheduler } = makeController();
+  controller.addBot();
+  controller.newOrder('NORMAL'); // #1001 -> picked
+  controller.newOrder('NORMAL'); // #1002 -> pending
+  assert.equal(controller.bots[0].currentOrder?.id, 1001);
+
+  controller.removeBot();
+
+  assert.deepEqual(pendingIds(controller), [1001, 1002]);
+  assert.equal(controller.bots.length, 0);
+
+  scheduler.flushAll();
+  assert.deepEqual(completedIds(controller), []); // no phantom completion
+  assert.equal(scheduler.pendingTimers, 0);
+});
+
+test('requeue preserves arrival order even with multiple bots removed', () => {
+  const { controller } = makeController();
+  controller.addBot();
+  controller.addBot();
+  controller.newOrder('NORMAL'); // #1001 -> Bot #1
+  controller.newOrder('NORMAL'); // #1002 -> Bot #2
+  controller.newOrder('NORMAL'); // #1003 -> pending
+  assert.deepEqual(pendingIds(controller), [1003]);
+
+  controller.removeBot(); // returns #1002
+  controller.removeBot(); // returns #1001
+
+  assert.deepEqual(pendingIds(controller), [1001, 1002, 1003]);
+});
+
+test('removing an idle bot is a no-op for orders', () => {
+  const { controller } = makeController();
+  controller.addBot();
+  controller.newOrder('NORMAL'); // #1001 -> processing
+  controller.addBot(); //            Bot #2 idle
+
+  controller.removeBot(); // removes idle Bot #2
+  assert.equal(controller.bots.length, 1);
+  assert.equal(controller.bots[0].currentOrder?.id, 1001);
+  assert.deepEqual(pendingIds(controller), []);
+});

--- a/src/order-controller.ts
+++ b/src/order-controller.ts
@@ -1,0 +1,153 @@
+export type OrderType = 'NORMAL' | 'VIP';
+export type OrderStatus = 'PENDING' | 'PROCESSING' | 'COMPLETE';
+
+export interface Order {
+  id: number;
+  type: OrderType;
+  status: OrderStatus;
+}
+
+export type BotStatus = 'IDLE' | 'PROCESSING';
+export type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface Bot {
+  id: number;
+  status: BotStatus;
+  currentOrder: Order | null;
+  timer: TimerHandle | null;
+}
+
+export type ControllerEvent =
+  | { type: 'ORDER_CREATED'; order: Order }
+  | { type: 'BOT_CREATED'; bot: Bot }
+  | { type: 'BOT_PICKED'; bot: Bot; order: Order }
+  | { type: 'ORDER_COMPLETED'; bot: Bot; order: Order }
+  | { type: 'BOT_IDLE'; bot: Bot }
+  | { type: 'BOT_DESTROYED'; bot: Bot; returnedOrder: Order | null };
+
+export type EventListener = (event: ControllerEvent) => void;
+
+export interface OrderControllerOptions {
+  processingMs?: number;
+  setTimeoutFn?: (callback: () => void, ms: number) => TimerHandle;
+  clearTimeoutFn?: (handle: TimerHandle) => void;
+}
+
+export class OrderController {
+  readonly pending: Order[] = [];
+  readonly completed: Order[] = [];
+  readonly bots: Bot[] = [];
+
+  private nextOrderId = 1000;
+  private nextBotId = 0;
+
+  private readonly processingMs: number;
+  private readonly setTimeoutFn: (callback: () => void, ms: number) => TimerHandle;
+  private readonly clearTimeoutFn: (handle: TimerHandle) => void;
+
+  private readonly listeners: EventListener[] = [];
+
+  constructor(options: OrderControllerOptions = {}) {
+    this.processingMs = options.processingMs ?? 10_000;
+    this.setTimeoutFn = options.setTimeoutFn ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimeoutFn = options.clearTimeoutFn ?? ((h) => clearTimeout(h));
+  }
+
+  on(listener: EventListener): this {
+    this.listeners.push(listener);
+    return this;
+  }
+
+  private emit(event: ControllerEvent): void {
+    for (const listener of this.listeners) listener(event);
+  }
+
+  private static rank(order: Order): number {
+    return order.type === 'VIP' ? 0 : 1;
+  }
+
+  // VIP before Normal; within a tier, the earlier order id first (FIFO).
+  private comesBefore(a: Order, b: Order): boolean {
+    const ra = OrderController.rank(a);
+    const rb = OrderController.rank(b);
+    if (ra !== rb) return ra < rb;
+    return a.id < b.id;
+  }
+
+  // Used by both newOrder and removeBot, so a returned order keeps its priority.
+  private insert(order: Order): void {
+    const i = this.pending.findIndex((existing) => this.comesBefore(order, existing));
+    if (i === -1) this.pending.push(order);
+    else this.pending.splice(i, 0, order);
+  }
+
+  newOrder(type: OrderType): Order {
+    const order: Order = { id: ++this.nextOrderId, type, status: 'PENDING' };
+    this.insert(order);
+    this.emit({ type: 'ORDER_CREATED', order });
+    this.dispatch();
+    return order;
+  }
+
+  addBot(): Bot {
+    const bot: Bot = { id: ++this.nextBotId, status: 'IDLE', currentOrder: null, timer: null };
+    this.bots.push(bot);
+    this.emit({ type: 'BOT_CREATED', bot });
+    this.dispatch();
+    return bot;
+  }
+
+  removeBot(): Bot | null {
+    const bot = this.bots.pop();
+    if (!bot) return null;
+
+    let returnedOrder: Order | null = null;
+    if (bot.status === 'PROCESSING' && bot.currentOrder) {
+      if (bot.timer !== null) this.clearTimeoutFn(bot.timer); // cancel: avoid a phantom completion
+      const order = bot.currentOrder;
+      order.status = 'PENDING';
+      this.insert(order);
+      returnedOrder = order;
+      bot.currentOrder = null;
+      bot.timer = null;
+      bot.status = 'IDLE';
+    }
+
+    this.emit({ type: 'BOT_DESTROYED', bot, returnedOrder });
+    this.dispatch();
+    return bot;
+  }
+
+  private dispatch(): void {
+    for (const bot of this.bots) {
+      if (bot.status !== 'IDLE') continue;
+      if (this.pending.length === 0) break;
+
+      const order = this.pending.shift()!;
+      order.status = 'PROCESSING';
+      bot.currentOrder = order;
+      bot.status = 'PROCESSING';
+      this.emit({ type: 'BOT_PICKED', bot, order });
+      bot.timer = this.setTimeoutFn(() => this.complete(bot), this.processingMs);
+    }
+  }
+
+  private complete(bot: Bot): void {
+    const order = bot.currentOrder;
+    if (!order) return;
+
+    order.status = 'COMPLETE';
+    this.completed.push(order);
+    bot.currentOrder = null;
+    bot.timer = null;
+    bot.status = 'IDLE';
+    this.emit({ type: 'ORDER_COMPLETED', bot, order });
+
+    if (this.pending.length > 0) this.dispatch();
+    else this.emit({ type: 'BOT_IDLE', bot });
+  }
+
+  isDrained(): boolean {
+    return this.pending.length === 0 && this.bots.every((b) => b.status === 'IDLE');
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## McDonald's Order Controller — Backend (Node.js + TypeScript CLI)

### Summary

Implements the full backend requirement using **Node.js + TypeScript** as a CLI
application, with both a scripted demo (for CI / `result.txt`) and an
interactive CLI.

---

### What's Implemented

**Core order logic**
- Single priority-ordered queue — VIP orders always dequeue before Normal
  orders; FIFO is maintained within each type
- Order IDs are unique and auto-incrementing
- Bot removal targets the newest bot; any in-progress order is returned to its
  correct priority position so it isn't leapfrogged by orders that arrived later

**Bot behaviour**
- Each bot processes one order at a time (10s, configurable via `processingMs`)
- On completion, the bot immediately picks up the next pending order
- When nothing is pending, the bot goes IDLE and resumes as soon as an order arrives

**Interactive CLI**

    normal      add a Normal order
    vip         add a VIP order
    addbot      add a cooking bot
    removebot   remove the newest bot
    status      show pending / processing / completed
    help        list commands
    exit        quit

**CI scripts**

| Script | Does |
|---|---|
| `test.sh` | `npm install` + compile + 8 unit tests (`node --test`) |
| `build.sh` | `npm install` + compile TypeScript → `dist/` |
| `run.sh` | Runs the demo scenario; output → `scripts/result.txt` with HH:MM:SS timestamps |

---

### Test Coverage

8 unit tests covering: VIP priority, FIFO-within-tier, unique increasing IDs,
bot pick-up/completion, add-bot-starts-immediately, idle handling, requeue-by-
priority on bot removal, and the no-phantom-completion edge case. Tests use a
fake scheduler so they run instantly and deterministically. Verified on Node
22.19.0 (CI version) and Node 24.

---

### How to Run Locally

```bash
./scripts/build.sh   # install + compile
./scripts/test.sh    # run tests
./scripts/run.sh     # demo scenario → scripts/result.txt
npm run cli          # interactive CLI
```
