### PR TITLE
McDonald's Order Controller — Backend (Go CLI) · Lee Kai Wen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# --- Claude / local agent config ---
+.claude/
+CLAUDE.local.md
+
+# --- Go ---
+# Build output
+/bin/
+/dist/
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binaries / coverage
+*.test
+*.out
+coverage.*
+# Go workspace file
+go.work
+go.work.sum
+
+# --- Node (CI image installs Node; ignore in case of tooling) ---
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# --- Editors / IDE ---
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# --- OS ---
+.DS_Store
+.DS_Store?
+._*
+Thumbs.db
+desktop.ini

--- a/README.md
+++ b/README.md
@@ -1,4 +1,95 @@
 ## FeedMe Software Engineer Take Home Assignment
+
+## Solution Summary
+
+This submission implements the **backend CLI option in Go**. The application is an in-memory order
+controller with an interactive CLI for the interview round and a scripted demo for GitHub Actions.
+
+### Run
+
+```bash
+./scripts/test.sh
+./scripts/build.sh
+./scripts/run.sh
+```
+
+The run script writes timestamped demo output to `scripts/result.txt`, which is the file verified by
+the `backend-verify-result` GitHub Actions workflow.
+
+After building, the interactive CLI can be started with:
+
+```bash
+./bin/order-controller -i
+```
+
+Interactive commands:
+
+```text
+normal   create a Normal order
+vip      create a VIP order
++bot     add a cooking bot
+-bot     remove the newest cooking bot
+status   print current state
+quit     stop bots and exit
+```
+
+### Design
+
+- The core controller is UI-agnostic and lives under `internal/controller`.
+- A single mutex guards all mutable state: pending orders, processing bots, completed orders, and the
+  next order ID. Order ID generation is shared state, so it happens under that same lock.
+- Pending orders use one ordering rule everywhere: VIP before Normal, then lower order ID first.
+  The monotonic order ID therefore satisfies the "unique and increasing" requirement and restores
+  interrupted orders to their original FIFO position.
+- Each processing order is driven by a timer and a cancellable context. When completion fires, the
+  controller re-checks that the bot still owns that exact order before moving it to COMPLETE, so stale
+  completions after bot removal are ignored.
+- Tests use a minimal fake timer to make completion/cancellation interleavings deterministic. The fake
+  timer controls when completion fires; the mutex plus ownership re-check controls the outcome.
+
+### Requirements to Tests
+
+| Requirement | Test coverage |
+| --- | --- |
+| Normal order enters PENDING | `TestOrdersStayPendingWhenThereAreZeroBots` |
+| VIP enters before Normal and behind earlier VIPs | `TestVIPBeforeNormalFIFOWithinKind` |
+| Order number is unique and increasing | `TestOrderIDsUniqueAndIncreasing` |
+| `+bot` immediately processes pending work | `TestAddingBotImmediatelyPicksUpPendingWork` |
+| Bot completes an order and picks the next one | `TestBotCompletesThenPicksNextOrder` |
+| Idle bot waits for future work | `TestIdleBotPicksUpNewlyArrivingOrder` |
+| `-bot` removes the newest bot | `TestRemoveBotTargetsNewestBotLIFO` |
+| Removing an idle bot does not affect orders | `TestRemovingIdleBotDoesNotAffectOrders` |
+| Removing a processing bot restores original queue position | `TestRemovingProcessingBotRequeuesAtExactPriorityPosition`, `TestRequeuedVIPPreservesFIFOAmongVIPs`, `TestMultiBotRemovalRestoresReturnedOrdersInOriginalOrder` |
+| Returned work is assigned to another idle bot immediately | `TestRequeuedOrderIsImmediatelyPickedUpByRemainingIdleBot` |
+| Timer/removal race does not lose or duplicate orders | `TestStaleCompletionAfterRemovalCannotDuplicateOrLoseOrder`, `TestRandomizedOperationsPreserveOrderConservation` |
+| Interactive CLI commands map to controller operations | `TestExecuteCommandAliasesAndStatus`, `TestExecuteCommandUnknownAndQuit` |
+
+### Scope Decisions
+
+This is intentionally not a web app, database-backed service, Docker setup, or framework-heavy
+project. The brief asks for either a frontend or backend implementation and explicitly cautions
+against over-engineering, so this submission focuses on the backend track: the controller state
+machine, deterministic tests, CI scripts, and an interview-ready CLI.
+
+### Full-system Extensibility
+
+The controller is designed so a web UI can be added without reimplementing order logic. A thin
+`net/http` adapter would call the same mutation methods (`AddOrder`, `AddBot`, `RemoveBot`) and render
+`Snapshot()` as JSON or server-sent events:
+
+```go
+http.HandleFunc("/api/state", func(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(controller.Snapshot())
+})
+```
+
+That extension is deliberately not included here: the assignment asks for one track, and keeping the
+core UI-agnostic gives the extension point without adding unrequested infrastructure.
+
+AI was used to help enumerate adversarial edge cases such as concurrent removal, stale timer
+completion, and order conservation. Those cases were treated as hypotheses, encoded as deterministic
+tests, and verified with `go test -race`.
+
 Below is a take home assignment before the interview of the position. You are required to
 1. Understand the situation and use case. You may contact the interviewer for further clarification.
 2. implement the requirement with **either frontend or backend components**.

--- a/cmd/order-controller/main.go
+++ b/cmd/order-controller/main.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"order-controller/internal/controller"
+)
+
+func main() {
+	demo := flag.Bool("demo", false, "run the scripted demo")
+	interactive := flag.Bool("i", false, "run the interactive CLI")
+	duration := flag.Duration("duration", controller.DefaultProcessDuration, "order processing duration")
+	flag.Parse()
+
+	logger := newLogger(os.Stdout)
+	c := controller.New(controller.Options{
+		ProcessDuration: *duration,
+		OnEvent:         logger.event,
+	})
+
+	if *demo {
+		runDemo(c, logger)
+		return
+	}
+
+	if *interactive || !*demo {
+		runInteractive(c, logger, os.Stdin)
+	}
+}
+
+type logger struct {
+	mu  sync.Mutex
+	out io.Writer
+}
+
+func newLogger(out io.Writer) *logger {
+	return &logger{out: out}
+}
+
+func (l *logger) event(event controller.Event) {
+	switch event.Type {
+	case controller.EventOrderCreated:
+		l.printf("%s Order #%d -> PENDING", event.Order.Kind, event.Order.ID)
+	case controller.EventBotCreated:
+		l.printf("Bot #%d created", event.BotID)
+	case controller.EventOrderPicked:
+		l.printf("Bot #%d picked up %s Order #%d -> PROCESSING", event.BotID, event.Order.Kind, event.Order.ID)
+	case controller.EventOrderCompleted:
+		l.printf("Bot #%d completed %s Order #%d -> COMPLETE", event.BotID, event.Order.Kind, event.Order.ID)
+	case controller.EventBotIdle:
+		l.printf("Bot #%d is IDLE", event.BotID)
+	case controller.EventBotRemoved:
+		l.printf("Bot #%d destroyed", event.BotID)
+	case controller.EventOrderRequeued:
+		l.printf("%s Order #%d returned to PENDING", event.Order.Kind, event.Order.ID)
+	case controller.EventNoBotToRemove:
+		l.printf("No bots to destroy")
+	}
+}
+
+func (l *logger) printf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintf(l.out, "[%s] %s\n", time.Now().Format("15:04:05"), fmt.Sprintf(format, args...))
+}
+
+func runDemo(c *controller.Controller, log *logger) {
+	log.printf("Demo started")
+	c.AddOrder(controller.Normal)
+	c.AddOrder(controller.Normal)
+	c.AddOrder(controller.VIP)
+	c.AddBot()
+	c.AddBot()
+	time.Sleep(time.Second)
+	c.RemoveBot()
+	c.AddBot()
+	if !c.WaitDrained(45 * time.Second) {
+		log.printf("Demo timed out before all orders completed")
+	}
+	printSnapshot(log, c.Snapshot())
+	log.printf("Demo completed")
+}
+
+func runInteractive(c *controller.Controller, log *logger, in io.Reader) {
+	log.printf("Interactive CLI ready. Commands: normal, vip, +bot, -bot, status, quit")
+	scanner := bufio.NewScanner(in)
+	for {
+		fmt.Fprint(os.Stdout, "> ")
+		if !scanner.Scan() {
+			log.printf("Input closed")
+			return
+		}
+		if executeCommand(strings.TrimSpace(scanner.Text()), c, log) {
+			return
+		}
+	}
+}
+
+func executeCommand(input string, c *controller.Controller, log *logger) bool {
+	cmd := strings.ToLower(strings.TrimSpace(input))
+	switch cmd {
+	case "normal", "n":
+		c.AddOrder(controller.Normal)
+	case "vip", "v":
+		c.AddOrder(controller.VIP)
+	case "+bot", "+", "addbot", "add bot":
+		c.AddBot()
+	case "-bot", "-", "removebot", "remove bot":
+		c.RemoveBot()
+	case "status", "s":
+		printSnapshot(log, c.Snapshot())
+	case "quit", "q", "exit":
+		log.printf("Stopping bots and exiting")
+		c.StopAll()
+		return true
+	case "":
+	default:
+		log.printf("Unknown command: %s", cmd)
+	}
+	return false
+}
+
+func printSnapshot(log *logger, snap controller.Snapshot) {
+	log.printf("Status: pending=%s processing=%s completed=%s bots=%s",
+		formatOrders(snap.Pending),
+		formatProcessing(snap.Processing),
+		formatOrders(snap.Completed),
+		formatBots(snap.Bots),
+	)
+}
+
+func formatOrders(orders []controller.OrderView) string {
+	if len(orders) == 0 {
+		return "[]"
+	}
+	parts := make([]string, 0, len(orders))
+	for _, order := range orders {
+		parts = append(parts, fmt.Sprintf("%s#%d", order.Kind, order.ID))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func formatProcessing(items []controller.ProcessingView) string {
+	if len(items) == 0 {
+		return "[]"
+	}
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		parts = append(parts, fmt.Sprintf("Bot#%d:%s#%d", item.BotID, item.Order.Kind, item.Order.ID))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func formatBots(bots []controller.BotView) string {
+	if len(bots) == 0 {
+		return "[]"
+	}
+	parts := make([]string, 0, len(bots))
+	for _, bot := range bots {
+		if bot.OrderID == 0 {
+			parts = append(parts, fmt.Sprintf("Bot#%d:%s", bot.ID, bot.Status))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("Bot#%d:%s(Order#%d)", bot.ID, bot.Status, bot.OrderID))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}

--- a/cmd/order-controller/main_test.go
+++ b/cmd/order-controller/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"order-controller/internal/controller"
+)
+
+func TestExecuteCommandAliasesAndStatus(t *testing.T) {
+	var out bytes.Buffer
+	log := newLogger(&out)
+	c := controller.New(controller.Options{
+		ProcessDuration: time.Hour,
+		OnEvent:         log.event,
+	})
+
+	for _, cmd := range []string{" n ", "v", "+", "add bot", "status"} {
+		if executeCommand(cmd, c, log) {
+			t.Fatalf("command %q should not quit", cmd)
+		}
+	}
+
+	snap := c.Snapshot()
+	if len(snap.Pending) != 0 {
+		t.Fatalf("pending = %+v, want empty because two bots should pick both orders", snap.Pending)
+	}
+	if len(snap.Processing) != 2 {
+		t.Fatalf("processing count = %d, want 2", len(snap.Processing))
+	}
+
+	text := out.String()
+	for _, want := range []string{
+		"Normal Order #1 -> PENDING",
+		"VIP Order #2 -> PENDING",
+		"Bot #1 picked up VIP Order #2 -> PROCESSING",
+		"Bot #2 picked up Normal Order #1 -> PROCESSING",
+		"Status: pending=[]",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestExecuteCommandUnknownAndQuit(t *testing.T) {
+	var out bytes.Buffer
+	log := newLogger(&out)
+	c := controller.New(controller.Options{
+		ProcessDuration: time.Hour,
+		OnEvent:         log.event,
+	})
+
+	if executeCommand("wat", c, log) {
+		t.Fatal("unknown command should not quit")
+	}
+	c.AddOrder(controller.VIP)
+	c.AddBot()
+	if !executeCommand("q", c, log) {
+		t.Fatal("q should quit")
+	}
+
+	text := out.String()
+	for _, want := range []string{
+		"Unknown command: wat",
+		"Stopping bots and exiting",
+		"Bot #1 destroyed",
+		"VIP Order #1 returned to PENDING",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module order-controller
+
+go 1.23

--- a/internal/controller/bot.go
+++ b/internal/controller/bot.go
@@ -1,0 +1,42 @@
+package controller
+
+import "context"
+
+type BotStatus string
+
+const (
+	BotIdle       BotStatus = "IDLE"
+	BotProcessing BotStatus = "PROCESSING"
+)
+
+type bot struct {
+	id           int
+	current      *Order
+	cancel       context.CancelFunc
+	done         chan struct{}
+	idleReported bool
+}
+
+func (b *bot) status() BotStatus {
+	if b.current != nil {
+		return BotProcessing
+	}
+	return BotIdle
+}
+
+type BotView struct {
+	ID      int
+	Status  BotStatus
+	OrderID int
+}
+
+func viewBot(b *bot) BotView {
+	view := BotView{
+		ID:     b.id,
+		Status: b.status(),
+	}
+	if b.current != nil {
+		view.OrderID = b.current.ID
+	}
+	return view
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,0 +1,287 @@
+package controller
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const DefaultProcessDuration = 10 * time.Second
+
+type EventType string
+
+const (
+	EventOrderCreated   EventType = "order_created"
+	EventBotCreated     EventType = "bot_created"
+	EventOrderPicked    EventType = "order_picked"
+	EventOrderCompleted EventType = "order_completed"
+	EventBotIdle        EventType = "bot_idle"
+	EventBotRemoved     EventType = "bot_removed"
+	EventOrderRequeued  EventType = "order_requeued"
+	EventNoBotToRemove  EventType = "no_bot_to_remove"
+)
+
+type Event struct {
+	Type   EventType
+	Order  OrderView
+	BotID  int
+	Detail string
+}
+
+type Options struct {
+	Timer           Timer
+	ProcessDuration time.Duration
+	OnEvent         func(Event)
+}
+
+type Controller struct {
+	mu      sync.Mutex
+	timer   Timer
+	procDur time.Duration
+	onEvent func(Event)
+	pending []*Order
+	bots    []*bot
+	done    []*Order
+	all     []*Order
+	nextID  int
+	nextBot int
+}
+
+func New(opts Options) *Controller {
+	timer := opts.Timer
+	if timer == nil {
+		timer = RealTimer{}
+	}
+	procDur := opts.ProcessDuration
+	if procDur == 0 {
+		procDur = DefaultProcessDuration
+	}
+	c := &Controller{
+		timer:   timer,
+		procDur: procDur,
+		onEvent: opts.OnEvent,
+		nextID:  1,
+		nextBot: 1,
+	}
+	return c
+}
+
+func (c *Controller) AddOrder(kind Kind) OrderView {
+	c.mu.Lock()
+	order := &Order{ID: c.nextID, Kind: kind, Status: Pending}
+	c.nextID++
+	c.all = append(c.all, order)
+	c.pending = insertOrdered(c.pending, order)
+	view := viewOrder(order)
+	events := []Event{{Type: EventOrderCreated, Order: view}}
+	events = append(events, c.dispatchLocked()...)
+	c.mu.Unlock()
+	c.emit(events)
+	return view
+}
+
+func (c *Controller) AddBot() BotView {
+	c.mu.Lock()
+	b := &bot{id: c.nextBot}
+	c.nextBot++
+	c.bots = append(c.bots, b)
+	view := viewBot(b)
+	events := []Event{{Type: EventBotCreated, BotID: b.id}}
+	events = append(events, c.dispatchLocked()...)
+	c.mu.Unlock()
+	c.emit(events)
+	return view
+}
+
+func (c *Controller) RemoveBot() bool {
+	c.mu.Lock()
+	if len(c.bots) == 0 {
+		c.mu.Unlock()
+		c.emit([]Event{{Type: EventNoBotToRemove}})
+		return false
+	}
+
+	idx := len(c.bots) - 1
+	b := c.bots[idx]
+	c.bots = c.bots[:idx]
+
+	var wait <-chan struct{}
+	if b.done != nil {
+		wait = b.done
+	}
+	if b.cancel != nil {
+		b.cancel()
+	}
+
+	events := []Event{{Type: EventBotRemoved, BotID: b.id}}
+	if b.current != nil {
+		order := b.current
+		order.Status = Pending
+		b.current = nil
+		b.cancel = nil
+		b.done = nil
+		c.pending = insertOrdered(c.pending, order)
+		events = append(events, Event{Type: EventOrderRequeued, BotID: b.id, Order: viewOrder(order)})
+		events = append(events, c.dispatchLocked()...)
+	}
+	c.mu.Unlock()
+
+	if wait != nil {
+		<-wait
+	}
+	c.emit(events)
+	return true
+}
+
+func (c *Controller) Snapshot() Snapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.snapshotLocked()
+}
+
+func (c *Controller) WaitDrained(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		snap := c.Snapshot()
+		if len(snap.Pending) == 0 && len(snap.Processing) == 0 {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func (c *Controller) StopAll() {
+	for {
+		c.mu.Lock()
+		hasBot := len(c.bots) > 0
+		c.mu.Unlock()
+		if !hasBot {
+			return
+		}
+		c.RemoveBot()
+	}
+}
+
+type Snapshot struct {
+	Pending    []OrderView
+	Processing []ProcessingView
+	Completed  []OrderView
+	Bots       []BotView
+	AllOrders  []OrderView
+}
+
+type ProcessingView struct {
+	BotID int
+	Order OrderView
+}
+
+func (c *Controller) dispatchLocked() []Event {
+	var events []Event
+	for len(c.pending) > 0 {
+		b := c.firstIdleBotLocked()
+		if b == nil {
+			return events
+		}
+		order := c.pending[0]
+		copy(c.pending, c.pending[1:])
+		c.pending[len(c.pending)-1] = nil
+		c.pending = c.pending[:len(c.pending)-1]
+
+		order.Status = Processing
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		b.current = order
+		b.cancel = cancel
+		b.done = done
+		b.idleReported = false
+
+		events = append(events, Event{Type: EventOrderPicked, BotID: b.id, Order: viewOrder(order)})
+		timer := c.timer.After(c.procDur)
+		go c.process(b, order, ctx, done, timer)
+	}
+	for _, b := range c.bots {
+		if b.current == nil && !b.idleReported {
+			b.idleReported = true
+			events = append(events, Event{Type: EventBotIdle, BotID: b.id})
+		}
+	}
+	return events
+}
+
+func (c *Controller) firstIdleBotLocked() *bot {
+	for _, b := range c.bots {
+		if b.current == nil {
+			return b
+		}
+	}
+	return nil
+}
+
+func (c *Controller) process(b *bot, order *Order, ctx context.Context, done chan struct{}, timer <-chan time.Time) {
+	defer close(done)
+	select {
+	case <-timer:
+		events := c.finishOrder(b, order)
+		c.emit(events)
+	case <-ctx.Done():
+		return
+	}
+}
+
+func (c *Controller) finishOrder(b *bot, order *Order) []Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if b.current != order {
+		return nil
+	}
+
+	b.current = nil
+	b.cancel = nil
+	b.done = nil
+	order.Status = Complete
+	c.done = append(c.done, order)
+
+	events := []Event{{Type: EventOrderCompleted, BotID: b.id, Order: viewOrder(order)}}
+	events = append(events, c.dispatchLocked()...)
+	return events
+}
+
+func (c *Controller) snapshotLocked() Snapshot {
+	snap := Snapshot{}
+	snap.Pending = make([]OrderView, 0, len(c.pending))
+	for _, order := range c.pending {
+		snap.Pending = append(snap.Pending, viewOrder(order))
+	}
+	snap.Completed = make([]OrderView, 0, len(c.done))
+	for _, order := range c.done {
+		snap.Completed = append(snap.Completed, viewOrder(order))
+	}
+	snap.Bots = make([]BotView, 0, len(c.bots))
+	for _, b := range c.bots {
+		snap.Bots = append(snap.Bots, viewBot(b))
+		if b.current != nil {
+			snap.Processing = append(snap.Processing, ProcessingView{
+				BotID: b.id,
+				Order: viewOrder(b.current),
+			})
+		}
+	}
+	snap.AllOrders = make([]OrderView, 0, len(c.all))
+	for _, order := range c.all {
+		snap.AllOrders = append(snap.AllOrders, viewOrder(order))
+	}
+	return snap
+}
+
+func (c *Controller) emit(events []Event) {
+	if c.onEvent == nil {
+		return
+	}
+	for _, event := range events {
+		c.onEvent(event)
+	}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,429 @@
+package controller
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeTimer struct {
+	mu     sync.Mutex
+	timers []chan time.Time
+}
+
+func (f *fakeTimer) After(time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	f.mu.Lock()
+	f.timers = append(f.timers, ch)
+	f.mu.Unlock()
+	return ch
+}
+
+func (f *fakeTimer) FireNext() bool {
+	f.mu.Lock()
+	if len(f.timers) == 0 {
+		f.mu.Unlock()
+		return false
+	}
+	ch := f.timers[0]
+	copy(f.timers, f.timers[1:])
+	f.timers[len(f.timers)-1] = nil
+	f.timers = f.timers[:len(f.timers)-1]
+	f.mu.Unlock()
+	ch <- time.Now()
+	return true
+}
+
+func (f *fakeTimer) FireAll() {
+	for f.FireNext() {
+	}
+}
+
+func newTestController() (*Controller, *fakeTimer) {
+	timer := &fakeTimer{}
+	return New(Options{Timer: timer, ProcessDuration: 10 * time.Second}), timer
+}
+
+func TestOrderIDsUniqueAndIncreasing(t *testing.T) {
+	c, _ := newTestController()
+
+	a := c.AddOrder(Normal)
+	b := c.AddOrder(VIP)
+	d := c.AddOrder(Normal)
+
+	if a.ID != 1 || b.ID != 2 || d.ID != 3 {
+		t.Fatalf("ids = [%d %d %d], want [1 2 3]", a.ID, b.ID, d.ID)
+	}
+	assertConservation(t, c.Snapshot())
+}
+
+func TestVIPBeforeNormalFIFOWithinKind(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddOrder(Normal) // #1
+	c.AddOrder(Normal) // #2
+	c.AddOrder(VIP)    // #3
+	c.AddOrder(VIP)    // #4
+	c.AddOrder(Normal) // #5
+
+	if got, want := orderIDs(c.Snapshot().Pending), []int{3, 4, 1, 2, 5}; !equalInts(got, want) {
+		t.Fatalf("pending = %v, want %v", got, want)
+	}
+	assertConservation(t, c.Snapshot())
+}
+
+func TestOrdersStayPendingWhenThereAreZeroBots(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddOrder(Normal)
+	c.AddOrder(VIP)
+
+	snap := c.Snapshot()
+	if got, want := orderIDs(snap.Pending), []int{2, 1}; !equalInts(got, want) {
+		t.Fatalf("pending = %v, want %v", got, want)
+	}
+	if len(snap.Processing) != 0 || len(snap.Completed) != 0 {
+		t.Fatalf("unexpected non-pending orders: %+v", snap)
+	}
+	assertConservation(t, snap)
+}
+
+func TestAddingBotImmediatelyPicksUpPendingWork(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddOrder(VIP)
+	c.AddBot()
+
+	snap := c.Snapshot()
+	if len(snap.Pending) != 0 {
+		t.Fatalf("pending = %v, want empty", snap.Pending)
+	}
+	if got, want := processingIDs(snap), []int{1}; !equalInts(got, want) {
+		t.Fatalf("processing = %v, want %v", got, want)
+	}
+	assertConservation(t, snap)
+}
+
+func TestIdleBotPicksUpNewlyArrivingOrder(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddBot()
+	c.AddOrder(Normal)
+
+	snap := c.Snapshot()
+	if got, want := processingIDs(snap), []int{1}; !equalInts(got, want) {
+		t.Fatalf("processing = %v, want %v", got, want)
+	}
+	if snap.Bots[0].Status != BotProcessing {
+		t.Fatalf("bot status = %s, want %s", snap.Bots[0].Status, BotProcessing)
+	}
+	assertConservation(t, snap)
+}
+
+func TestBotCompletesThenPicksNextOrder(t *testing.T) {
+	c, timer := newTestController()
+
+	c.AddOrder(VIP)    // #1
+	c.AddOrder(Normal) // #2
+	c.AddBot()
+
+	timer.FireNext()
+	mustEventually(t, func() bool {
+		snap := c.Snapshot()
+		return len(snap.Completed) == 1 && len(snap.Processing) == 1 && snap.Processing[0].Order.ID == 2
+	})
+
+	timer.FireNext()
+	mustEventually(t, func() bool {
+		return len(c.Snapshot().Completed) == 2
+	})
+	assertConservation(t, c.Snapshot())
+}
+
+func TestRemoveBotTargetsNewestBotLIFO(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddOrder(Normal) // #1
+	c.AddOrder(Normal) // #2
+	c.AddBot()         // Bot #1 picks #1
+	c.AddBot()         // Bot #2 picks #2
+
+	c.RemoveBot()
+
+	snap := c.Snapshot()
+	if got, want := botIDs(snap.Bots), []int{1}; !equalInts(got, want) {
+		t.Fatalf("bots = %v, want %v", got, want)
+	}
+	if got, want := orderIDs(snap.Pending), []int{2}; !equalInts(got, want) {
+		t.Fatalf("pending = %v, want returned newest bot order %v", got, want)
+	}
+	assertConservation(t, snap)
+}
+
+func TestRemovingIdleBotDoesNotAffectOrders(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddBot()         // Bot #1 idle
+	c.AddOrder(Normal) // Bot #1 picks #1
+	c.AddBot()         // Bot #2 idle and newest
+
+	c.RemoveBot()
+
+	snap := c.Snapshot()
+	if got, want := botIDs(snap.Bots), []int{1}; !equalInts(got, want) {
+		t.Fatalf("bots = %v, want %v", got, want)
+	}
+	if got, want := processingIDs(snap), []int{1}; !equalInts(got, want) {
+		t.Fatalf("processing = %v, want %v", got, want)
+	}
+	if len(snap.Pending) != 0 {
+		t.Fatalf("pending = %v, want empty", snap.Pending)
+	}
+	assertConservation(t, snap)
+}
+
+func TestRemovingProcessingBotRequeuesAtExactPriorityPosition(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddOrder(Normal) // #1, picked by bot
+	c.AddBot()
+	c.AddOrder(Normal) // #2
+	c.AddOrder(VIP)    // #3
+
+	c.RemoveBot()
+
+	snap := c.Snapshot()
+	if got, want := orderIDs(snap.Pending), []int{3, 1, 2}; !equalInts(got, want) {
+		t.Fatalf("pending = %v, want %v", got, want)
+	}
+	assertConservation(t, snap)
+}
+
+func TestRequeuedVIPPreservesFIFOAmongVIPs(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddOrder(VIP) // #1, picked by bot
+	c.AddBot()
+	c.AddOrder(VIP) // #2, pending behind #1
+	c.AddOrder(VIP) // #3, pending behind #2
+
+	c.RemoveBot()
+
+	snap := c.Snapshot()
+	if got, want := orderIDs(snap.Pending), []int{1, 2, 3}; !equalInts(got, want) {
+		t.Fatalf("pending = %v, want %v", got, want)
+	}
+	assertConservation(t, snap)
+}
+
+func TestRequeuedOrderIsImmediatelyPickedUpByRemainingIdleBot(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddBot()         // Bot #1 idle
+	c.AddBot()         // Bot #2 idle
+	c.AddOrder(Normal) // Bot #1 picks #1
+
+	c.mu.Lock()
+	c.bots[0], c.bots[1] = c.bots[1], c.bots[0] // make busy bot newest; older bot remains idle
+	c.mu.Unlock()
+
+	c.RemoveBot()
+
+	snap := c.Snapshot()
+	if got, want := botIDs(snap.Bots), []int{2}; !equalInts(got, want) {
+		t.Fatalf("bots = %v, want remaining idle bot %v", got, want)
+	}
+	if got, want := processingIDs(snap), []int{1}; !equalInts(got, want) {
+		t.Fatalf("processing = %v, want requeued order immediately reassigned %v", got, want)
+	}
+	if len(snap.Pending) != 0 {
+		t.Fatalf("pending = %v, want empty after immediate reassignment", snap.Pending)
+	}
+	assertConservation(t, snap)
+}
+
+func TestMultiBotRemovalRestoresReturnedOrdersInOriginalOrder(t *testing.T) {
+	c, _ := newTestController()
+
+	c.AddOrder(Normal) // #1 -> Bot #1
+	c.AddOrder(Normal) // #2 -> Bot #2
+	c.AddOrder(Normal) // #3 stays pending
+	c.AddBot()
+	c.AddBot()
+	c.AddOrder(VIP) // #4 jumps ahead of pending normals
+
+	c.RemoveBot() // returns #2
+	c.RemoveBot() // returns #1
+
+	snap := c.Snapshot()
+	if got, want := orderIDs(snap.Pending), []int{4, 1, 2, 3}; !equalInts(got, want) {
+		t.Fatalf("pending = %v, want %v", got, want)
+	}
+	assertConservation(t, snap)
+}
+
+func TestStaleCompletionAfterRemovalCannotDuplicateOrLoseOrder(t *testing.T) {
+	c, timer := newTestController()
+
+	c.AddOrder(Normal)
+	c.AddBot()
+
+	c.mu.Lock()
+	b := c.bots[0]
+	order := b.current
+	c.mu.Unlock()
+
+	c.RemoveBot()
+	if events := c.finishOrder(b, order); len(events) != 0 {
+		t.Fatalf("stale completion emitted events: %+v", events)
+	}
+	timer.FireAll()
+
+	mustEventually(t, func() bool {
+		snap := c.Snapshot()
+		return len(snap.Pending) == 1 && len(snap.Completed) == 0 && len(snap.Processing) == 0
+	})
+	assertConservation(t, c.Snapshot())
+}
+
+func TestRandomizedOperationsPreserveOrderConservation(t *testing.T) {
+	c := New(Options{ProcessDuration: time.Millisecond})
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 4)
+	for worker := 0; worker < 4; worker++ {
+		wg.Add(1)
+		go func(seed int64) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(seed))
+			for i := 0; i < 80; i++ {
+				switch rng.Intn(5) {
+				case 0:
+					c.AddOrder(VIP)
+				case 1, 2:
+					c.AddOrder(Normal)
+				case 3:
+					c.AddBot()
+				case 4:
+					c.RemoveBot()
+				}
+				if err := conservationError(c.Snapshot()); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(int64(worker + 1))
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(20 * time.Millisecond)
+	assertConservation(t, c.Snapshot())
+	c.StopAll()
+	assertConservation(t, c.Snapshot())
+}
+
+func assertConservation(t *testing.T, snap Snapshot) {
+	t.Helper()
+	if err := conservationError(snap); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func conservationError(snap Snapshot) error {
+	seen := map[int]string{}
+	add := func(order OrderView, where string) error {
+		if prior, ok := seen[order.ID]; ok {
+			return fmt.Errorf("order #%d appears in both %s and %s; snapshot=%+v", order.ID, prior, where, snap)
+		}
+		seen[order.ID] = where
+		return nil
+	}
+	for _, order := range snap.Pending {
+		if order.Status != Pending {
+			return fmt.Errorf("pending order has status %s: %+v", order.Status, order)
+		}
+		if err := add(order, "pending"); err != nil {
+			return err
+		}
+	}
+	for _, item := range snap.Processing {
+		if item.Order.Status != Processing {
+			return fmt.Errorf("processing order has status %s: %+v", item.Order.Status, item)
+		}
+		if err := add(item.Order, "processing"); err != nil {
+			return err
+		}
+	}
+	for _, order := range snap.Completed {
+		if order.Status != Complete {
+			return fmt.Errorf("completed order has status %s: %+v", order.Status, order)
+		}
+		if err := add(order, "completed"); err != nil {
+			return err
+		}
+	}
+	if len(seen) != len(snap.AllOrders) {
+		return fmt.Errorf("visible orders = %d, all orders = %d; snapshot=%+v", len(seen), len(snap.AllOrders), snap)
+	}
+	for _, order := range snap.AllOrders {
+		if _, ok := seen[order.ID]; !ok {
+			return fmt.Errorf("order #%d is lost; snapshot=%+v", order.ID, snap)
+		}
+	}
+	return nil
+}
+
+func mustEventually(t *testing.T, predicate func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if predicate() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition was not met before deadline")
+}
+
+func orderIDs(orders []OrderView) []int {
+	ids := make([]int, 0, len(orders))
+	for _, order := range orders {
+		ids = append(ids, order.ID)
+	}
+	return ids
+}
+
+func processingIDs(snap Snapshot) []int {
+	ids := make([]int, 0, len(snap.Processing))
+	for _, item := range snap.Processing {
+		ids = append(ids, item.Order.ID)
+	}
+	return ids
+}
+
+func botIDs(bots []BotView) []int {
+	ids := make([]int, 0, len(bots))
+	for _, bot := range bots {
+		ids = append(ids, bot.ID)
+	}
+	return ids
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/order.go
+++ b/internal/controller/order.go
@@ -1,0 +1,57 @@
+package controller
+
+type Kind string
+
+const (
+	Normal Kind = "Normal"
+	VIP    Kind = "VIP"
+)
+
+type Status string
+
+const (
+	Pending    Status = "PENDING"
+	Processing Status = "PROCESSING"
+	Complete   Status = "COMPLETE"
+)
+
+type Order struct {
+	ID     int
+	Kind   Kind
+	Status Status
+}
+
+func less(a, b *Order) bool {
+	if a.Kind != b.Kind {
+		return a.Kind == VIP
+	}
+	return a.ID < b.ID
+}
+
+func insertOrdered(orders []*Order, order *Order) []*Order {
+	pos := len(orders)
+	for i, existing := range orders {
+		if less(order, existing) {
+			pos = i
+			break
+		}
+	}
+	orders = append(orders, nil)
+	copy(orders[pos+1:], orders[pos:])
+	orders[pos] = order
+	return orders
+}
+
+type OrderView struct {
+	ID     int
+	Kind   Kind
+	Status Status
+}
+
+func viewOrder(order *Order) OrderView {
+	return OrderView{
+		ID:     order.ID,
+		Kind:   order.Kind,
+		Status: order.Status,
+	}
+}

--- a/internal/controller/timer.go
+++ b/internal/controller/timer.go
@@ -1,0 +1,13 @@
+package controller
+
+import "time"
+
+type Timer interface {
+	After(time.Duration) <-chan time.Time
+}
+
+type RealTimer struct{}
+
+func (RealTimer) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
-# Build Script
-# This script should contain all compilation steps for your CLI application
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
 
-echo "Building CLI application..."
-
-# For Go projects:
-# go build -o order-controller ./cmd/main.go
-
-# For Node.js projects:
-# npm install
-# npm run build (if needed)
-
-echo "Build completed"
+mkdir -p bin
+go build -o bin/order-controller ./cmd/order-controller

--- a/scripts/result.txt
+++ b/scripts/result.txt
@@ -1,26 +1,20 @@
-McDonald's Order Management System - Simulation Results
-
-[14:32:01] System initialized with 0 bots
-[14:32:01] Created Normal Order #1001 - Status: PENDING
-[14:32:02] Created VIP Order #1002 - Status: PENDING
-[14:32:02] Created Normal Order #1003 - Status: PENDING
-[14:32:03] Bot #1 created - Status: ACTIVE
-[14:32:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
-[14:32:04] Bot #2 created - Status: ACTIVE
-[14:32:04] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
-[14:32:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
-[14:32:13] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
-[14:32:14] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
-[14:32:14] Bot #2 is now IDLE - No pending orders
-[14:32:15] Created VIP Order #1004 - Status: PENDING
-[14:32:15] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
-[14:32:23] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 destroyed while IDLE
-[14:32:26] Bot #1 is now IDLE - No pending orders
-
-Final Status:
-- Total Orders Processed: 4 (2 VIP, 2 Normal)
-- Orders Completed: 4
-- Active Bots: 1
-- Pending Orders: 0
+[22:29:53] Demo started
+[22:29:53] Normal Order #1 -> PENDING
+[22:29:53] Normal Order #2 -> PENDING
+[22:29:53] VIP Order #3 -> PENDING
+[22:29:53] Bot #1 created
+[22:29:53] Bot #1 picked up VIP Order #3 -> PROCESSING
+[22:29:53] Bot #2 created
+[22:29:53] Bot #2 picked up Normal Order #1 -> PROCESSING
+[22:29:54] Bot #2 destroyed
+[22:29:54] Normal Order #1 returned to PENDING
+[22:29:54] Bot #3 created
+[22:29:54] Bot #3 picked up Normal Order #1 -> PROCESSING
+[22:30:03] Bot #1 completed VIP Order #3 -> COMPLETE
+[22:30:03] Bot #1 picked up Normal Order #2 -> PROCESSING
+[22:30:04] Bot #3 completed Normal Order #1 -> COMPLETE
+[22:30:04] Bot #3 is IDLE
+[22:30:13] Bot #1 completed Normal Order #2 -> COMPLETE
+[22:30:13] Bot #1 is IDLE
+[22:30:13] Status: pending=[] processing=[] completed=[VIP#3, Normal#1, Normal#2] bots=[Bot#1:IDLE, Bot#3:IDLE]
+[22:30:13] Demo completed

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
+set -euo pipefail
 
-# Run Script
-# This script should execute your CLI application and output results to result.txt
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
 
-echo "Running CLI application..."
+if [ ! -x bin/order-controller ]; then
+  "$ROOT_DIR/scripts/build.sh"
+fi
 
-# For Go projects:
-# ./order-controller > result.txt
-
-# For Node.js projects:
-# node index.js > result.txt
-# or npm start > result.txt
-
-# Temporary placeholder - remove this when you implement your CLI
-echo "Added 1 bot" > result.txt
-echo "status: bot: [1], order: []" >> result.txt
-
-echo "CLI application execution completed"
+bin/order-controller -demo > scripts/result.txt

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
+set -euo pipefail
 
-# Unit Test Script
-# This script should contain all unit test execution steps
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
 
-echo "Running unit tests..."
-
-# For Go projects:
-# go test ./... -v
-
-# For Node.js projects:
-# npm test
-
-echo "Unit tests completed"
+go test -race ./... -v


### PR DESCRIPTION
## Summary

Implements the backend CLI option in Go. An in-memory order controller where Normal/VIP orders flow PENDING → PROCESSING (10s per bot) → COMPLETE, with a dynamic pool of cooking bots that can be added and removed at runtime. The core is UI-agnostic; the CLI is a thin layer over it: interactive REPL for the demo round, plus scripted mode for the CI artifact.

## How to run / verify

```bash
./scripts/test.sh     # unit tests, run under go test -race
./scripts/build.sh    # builds bin/order-controller
./scripts/run.sh      # runs scripted demo -> scripts/result.txt
```

Interactive mode:

```bash
./bin/order-controller -i
# commands: normal, vip, +bot, -bot, status, quit
```

The `backend-verify-result` workflow passes. A requirements-to-tests mapping table is included in the README.

## Design decisions

**One ordering rule everywhere.** A single comparator, VIP before Normal and then lower order ID, governs both new orders and requeued ones. Order IDs are a monotonic counter allocated under the controller lock, so the ID is arrival order: it satisfies the unique/increasing requirement and doubles as the FIFO key. Because of this, a destroyed bot's in-progress order returns to its original position without special-case requeue logic.

**Concurrency model.** A single mutex guards all controller state. Each bot is a goroutine with a cancellable context. Removing a bot destroys the newest one (LIFO), cancels its context, and, if it was mid-process, returns the order to PENDING via the same ordering rule. Removal waits synchronously for the bot goroutine to finish.

**Timer-vs-removal race.** When a bot's 10s timer fires, completion re-checks under the lock that the bot still owns that exact order before moving it to COMPLETE. So if completion fires at the same instant the bot is removed, the order is never both completed and requeued, and never lost.

**Deterministic concurrency tests.** The processing timer is injectable; tests use a fake timer to make completion/cancellation interleavings deterministic. Tests assert a conservation invariant: every order is in exactly one of pending, processing, or complete. The suite also includes a randomized concurrent stress test and runs under `go test -race`.

## Scope

Per the brief, this is an in-memory prototype: no persistence, no framework, and no web layer. The core is intentionally UI-agnostic through `Snapshot()` and mutation methods, so an HTTP/SSE adapter or UI could attach without changing the engine. I kept that out of scope to focus on the hardest part of the backend track: concurrent state correctness.

## Production evolution

If this moved beyond prototype stage, I would add durable order storage, restart recovery for in-flight work, idempotent completion with ownership/fencing tokens, observability around queue depth and processing time, and a dashboard over the existing controller interface.

## AI usage

AI tools assisted implementation and review; correctness was gated by deterministic tests, a conservation invariant, and the race detector.