### PR TITLE
feat: implement Go order controller CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/order-controller

--- a/README.md
+++ b/README.md
@@ -62,3 +62,36 @@ You must implement **either** frontend or backend components as described below:
 - Testing, testing and testing. Make sure the prototype is functioning and meeting all the requirements.
 - Utilize coding agent to complete the assignment scope your working hour within 1 hour, do not over engineer it. However, ensure you read and understand what your code doing and apply good engineering practice.
 - Complete the implementation as clean as possible, clean code is a strong plus point, do not bring in all the fancy tech stuff.
+
+## Backend CLI Implementation
+
+This repository includes a Go CLI implementation for the backend option.
+
+### Scripts
+
+```bash
+./scripts/test.sh
+./scripts/build.sh
+./scripts/run.sh
+```
+
+`run.sh` writes the simulation output to `scripts/result.txt`. Every event line includes an `HH:MM:SS` timestamp.
+
+### Interactive CLI
+
+Build the binary first, then start the interactive shell:
+
+```bash
+./scripts/build.sh
+./bin/order-controller interactive
+```
+
+Commands:
+
+- `normal`: create a normal order
+- `vip`: create a VIP order
+- `+bot`: add a cooking bot
+- `-bot`: remove the newest cooking bot
+- `tick <seconds>`: advance the simulation clock
+- `status`: print current state
+- `quit`: exit

--- a/cmd/order-controller/main.go
+++ b/cmd/order-controller/main.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"se-take-home-assignment/internal/order"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdin io.Reader, stdout io.Writer) error {
+	command := "run"
+	if len(args) > 0 {
+		command = args[0]
+	}
+
+	switch command {
+	case "run", "demo", "simulate":
+		runDemo(stdout)
+	case "interactive", "shell":
+		return runInteractive(stdin, stdout)
+	case "help", "-h", "--help":
+		printUsage(stdout)
+	default:
+		return fmt.Errorf("unknown command %q; run with --help for usage", command)
+	}
+
+	return nil
+}
+
+func runDemo(stdout io.Writer) {
+	controller := order.NewController(demoStart())
+
+	controller.AddNormalOrder()
+	controller.Advance(time.Second)
+	controller.AddVIPOrder()
+	controller.Advance(time.Second)
+	controller.AddNormalOrder()
+	controller.Advance(time.Second)
+
+	controller.AddBot()
+	controller.Advance(time.Second)
+	controller.AddBot()
+	controller.Advance(4 * time.Second)
+
+	controller.RemoveBot()
+	controller.AddVIPOrder()
+	controller.AddBot()
+
+	controller.Advance(5 * time.Second)
+	controller.Advance(5 * time.Second)
+	controller.Advance(10 * time.Second)
+	controller.RemoveBot()
+
+	writeReport(stdout, controller)
+}
+
+func runInteractive(stdin io.Reader, stdout io.Writer) error {
+	controller := order.NewController(demoStart())
+	seenEvents := 0
+
+	fmt.Fprintln(stdout, "Interactive order controller. Type help for commands.")
+	printNewEvents(stdout, controller, &seenEvents)
+
+	scanner := bufio.NewScanner(stdin)
+	for {
+		fmt.Fprint(stdout, "> ")
+		if !scanner.Scan() {
+			fmt.Fprintln(stdout)
+			return scanner.Err()
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		quit, err := handleInteractiveCommand(line, controller, stdout)
+		if err != nil {
+			fmt.Fprintf(stdout, "[%s] ERROR: %s\n", controller.Now().Format("15:04:05"), err)
+			continue
+		}
+		if quit {
+			writeFinalStatus(stdout, controller)
+			return nil
+		}
+		printNewEvents(stdout, controller, &seenEvents)
+	}
+}
+
+func handleInteractiveCommand(line string, controller *order.Controller, stdout io.Writer) (bool, error) {
+	fields := strings.Fields(strings.ToLower(line))
+	if len(fields) == 0 {
+		return false, nil
+	}
+
+	switch fields[0] {
+	case "normal", "n":
+		controller.AddNormalOrder()
+	case "vip", "v":
+		controller.AddVIPOrder()
+	case "+bot", "bot+", "add-bot":
+		controller.AddBot()
+	case "-bot", "bot-", "remove-bot":
+		controller.RemoveBot()
+	case "tick", "advance":
+		if len(fields) != 2 {
+			return false, fmt.Errorf("%s requires a number of seconds", fields[0])
+		}
+		seconds, err := strconv.Atoi(fields[1])
+		if err != nil || seconds < 0 {
+			return false, fmt.Errorf("seconds must be a non-negative integer")
+		}
+		controller.Advance(time.Duration(seconds) * time.Second)
+	case "status":
+		writeFinalStatus(stdout, controller)
+	case "help":
+		printUsage(stdout)
+	case "quit", "exit":
+		return true, nil
+	default:
+		return false, fmt.Errorf("unknown command %q", fields[0])
+	}
+
+	return false, nil
+}
+
+func printUsage(stdout io.Writer) {
+	fmt.Fprintln(stdout, "Usage:")
+	fmt.Fprintln(stdout, "  order-controller run")
+	fmt.Fprintln(stdout, "  order-controller interactive")
+	fmt.Fprintln(stdout, "")
+	fmt.Fprintln(stdout, "Interactive commands:")
+	fmt.Fprintln(stdout, "  normal      create a normal order")
+	fmt.Fprintln(stdout, "  vip         create a VIP order")
+	fmt.Fprintln(stdout, "  +bot        add a cooking bot")
+	fmt.Fprintln(stdout, "  -bot        remove the newest cooking bot")
+	fmt.Fprintln(stdout, "  tick <sec>  advance the simulation clock")
+	fmt.Fprintln(stdout, "  status      print current state")
+	fmt.Fprintln(stdout, "  quit        exit")
+}
+
+func writeReport(stdout io.Writer, controller *order.Controller) {
+	fmt.Fprintf(stdout, "[%s] McDonald's Order Management System - Simulation Results\n", demoStart().Format("15:04:05"))
+	for _, event := range controller.Events() {
+		fmt.Fprintln(stdout, event.String())
+	}
+	writeFinalStatus(stdout, controller)
+}
+
+func writeFinalStatus(stdout io.Writer, controller *order.Controller) {
+	now := controller.Now().Format("15:04:05")
+	summary := controller.Summary()
+	snapshot := controller.Snapshot()
+
+	fmt.Fprintf(stdout, "[%s] Final Status: Orders Created=%d (%d VIP, %d Normal)\n", now, summary.OrdersCreated, summary.VIPCreated, summary.NormalCreated)
+	fmt.Fprintf(stdout, "[%s] Final Status: Orders Completed=%d\n", now, summary.OrdersComplete)
+	fmt.Fprintf(stdout, "[%s] Final Status: Active Bots=%d, Pending=%d, Processing=%d\n", now, summary.ActiveBots, summary.PendingOrders, summary.Processing)
+	fmt.Fprintf(stdout, "[%s] Pending Queue: %s\n", now, formatOrderViews(snapshot.Pending))
+	fmt.Fprintf(stdout, "[%s] Processing Orders: %s\n", now, formatProcessingViews(snapshot.Processing))
+	fmt.Fprintf(stdout, "[%s] Complete Orders: %s\n", now, formatOrderViews(snapshot.Completed))
+}
+
+func printNewEvents(stdout io.Writer, controller *order.Controller, seenEvents *int) {
+	events := controller.Events()
+	for _, event := range events[*seenEvents:] {
+		fmt.Fprintln(stdout, event.String())
+	}
+	*seenEvents = len(events)
+}
+
+func formatOrderViews(orders []order.OrderView) string {
+	if len(orders) == 0 {
+		return "[]"
+	}
+
+	parts := make([]string, 0, len(orders))
+	for _, order := range orders {
+		parts = append(parts, fmt.Sprintf("%s#%d", order.Kind, order.ID))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func formatProcessingViews(orders []order.ProcessingView) string {
+	if len(orders) == 0 {
+		return "[]"
+	}
+
+	parts := make([]string, 0, len(orders))
+	for _, processing := range orders {
+		parts = append(parts, fmt.Sprintf("Bot#%d->%s#%d", processing.BotID, processing.Kind, processing.OrderID))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func demoStart() time.Time {
+	return time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module se-take-home-assignment
+
+go 1.23

--- a/internal/order/controller.go
+++ b/internal/order/controller.go
@@ -1,0 +1,354 @@
+package order
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	firstOrderID       = 1001
+	ProcessingDuration = 10 * time.Second
+)
+
+type Kind string
+
+const (
+	KindNormal Kind = "Normal"
+	KindVIP    Kind = "VIP"
+)
+
+type Status string
+
+const (
+	StatusPending    Status = "PENDING"
+	StatusProcessing Status = "PROCESSING"
+	StatusComplete   Status = "COMPLETE"
+)
+
+type Event struct {
+	At      time.Time
+	Message string
+}
+
+func (e Event) String() string {
+	return fmt.Sprintf("[%s] %s", e.At.Format("15:04:05"), e.Message)
+}
+
+type OrderView struct {
+	ID     int
+	Kind   Kind
+	Status Status
+}
+
+type ProcessingView struct {
+	BotID   int
+	OrderID int
+	Kind    Kind
+	Started time.Time
+}
+
+type Snapshot struct {
+	Pending    []OrderView
+	Processing []ProcessingView
+	Completed  []OrderView
+	IdleBots   []int
+	BotIDs     []int
+}
+
+type Summary struct {
+	OrdersCreated  int
+	VIPCreated     int
+	NormalCreated  int
+	OrdersComplete int
+	ActiveBots     int
+	PendingOrders  int
+	Processing     int
+}
+
+type Controller struct {
+	now          time.Time
+	nextOrderID  int
+	nextBotID    int
+	nextSequence int
+
+	pending   []*Order
+	bots      []*Bot
+	completed []*Order
+	events    []Event
+
+	vipCreated    int
+	normalCreated int
+}
+
+type Order struct {
+	ID          int
+	Kind        Kind
+	Status      Status
+	sequence    int
+	CreatedAt   time.Time
+	StartedAt   time.Time
+	CompletedAt time.Time
+}
+
+type Bot struct {
+	ID        int
+	current   *Order
+	startedAt time.Time
+}
+
+func NewController(start time.Time) *Controller {
+	c := &Controller{
+		now:         start,
+		nextOrderID: firstOrderID,
+		nextBotID:   1,
+	}
+	c.logf("System initialized with 0 bots")
+	return c
+}
+
+func (c *Controller) Now() time.Time {
+	return c.now
+}
+
+func (c *Controller) Events() []Event {
+	events := make([]Event, len(c.events))
+	copy(events, c.events)
+	return events
+}
+
+func (c *Controller) AddNormalOrder() int {
+	return c.addOrder(KindNormal)
+}
+
+func (c *Controller) AddVIPOrder() int {
+	return c.addOrder(KindVIP)
+}
+
+func (c *Controller) AddBot() int {
+	id := c.nextBotID
+	c.nextBotID++
+
+	bot := &Bot{ID: id}
+	c.bots = append(c.bots, bot)
+	c.logf("Bot #%d created - Status: IDLE", id)
+
+	c.assignIdleBots()
+	if bot.current == nil {
+		c.logf("Bot #%d is IDLE - No pending orders", id)
+	}
+
+	return id
+}
+
+func (c *Controller) RemoveBot() (int, bool) {
+	if len(c.bots) == 0 {
+		c.logf("No bot available to destroy")
+		return 0, false
+	}
+
+	idx := len(c.bots) - 1
+	bot := c.bots[idx]
+	c.bots = c.bots[:idx]
+
+	if bot.current == nil {
+		c.logf("Bot #%d destroyed while IDLE", bot.ID)
+		return bot.ID, true
+	}
+
+	order := bot.current
+	order.StartedAt = time.Time{}
+	c.insertPending(order)
+	c.logf(
+		"Bot #%d destroyed while processing %s Order #%d - Order returned to PENDING",
+		bot.ID,
+		order.Kind,
+		order.ID,
+	)
+	c.assignIdleBots()
+
+	return bot.ID, true
+}
+
+func (c *Controller) Advance(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+
+	target := c.now.Add(d)
+	for {
+		bot, completedAt := c.nextCompletion(target)
+		if bot == nil {
+			break
+		}
+
+		c.now = completedAt
+		order := bot.current
+		bot.current = nil
+		bot.startedAt = time.Time{}
+
+		order.Status = StatusComplete
+		order.CompletedAt = c.now
+		c.completed = append(c.completed, order)
+		c.logf(
+			"Bot #%d completed %s Order #%d - Status: COMPLETE (Processing time: %s)",
+			bot.ID,
+			order.Kind,
+			order.ID,
+			ProcessingDuration,
+		)
+
+		c.assignIdleBots()
+		if bot.current == nil {
+			c.logf("Bot #%d is now IDLE - No pending orders", bot.ID)
+		}
+	}
+
+	c.now = target
+}
+
+func (c *Controller) Snapshot() Snapshot {
+	snapshot := Snapshot{
+		Pending:   make([]OrderView, 0, len(c.pending)),
+		Completed: make([]OrderView, 0, len(c.completed)),
+		BotIDs:    make([]int, 0, len(c.bots)),
+	}
+
+	for _, order := range c.pending {
+		snapshot.Pending = append(snapshot.Pending, viewOrder(order))
+	}
+	for _, order := range c.completed {
+		snapshot.Completed = append(snapshot.Completed, viewOrder(order))
+	}
+	for _, bot := range c.bots {
+		snapshot.BotIDs = append(snapshot.BotIDs, bot.ID)
+		if bot.current == nil {
+			snapshot.IdleBots = append(snapshot.IdleBots, bot.ID)
+			continue
+		}
+		snapshot.Processing = append(snapshot.Processing, ProcessingView{
+			BotID:   bot.ID,
+			OrderID: bot.current.ID,
+			Kind:    bot.current.Kind,
+			Started: bot.startedAt,
+		})
+	}
+
+	return snapshot
+}
+
+func (c *Controller) Summary() Summary {
+	snapshot := c.Snapshot()
+	return Summary{
+		OrdersCreated:  c.vipCreated + c.normalCreated,
+		VIPCreated:     c.vipCreated,
+		NormalCreated:  c.normalCreated,
+		OrdersComplete: len(snapshot.Completed),
+		ActiveBots:     len(snapshot.BotIDs),
+		PendingOrders:  len(snapshot.Pending),
+		Processing:     len(snapshot.Processing),
+	}
+}
+
+func (c *Controller) addOrder(kind Kind) int {
+	id := c.nextOrderID
+	c.nextOrderID++
+	c.nextSequence++
+
+	order := &Order{
+		ID:        id,
+		Kind:      kind,
+		Status:    StatusPending,
+		sequence:  c.nextSequence,
+		CreatedAt: c.now,
+	}
+
+	if kind == KindVIP {
+		c.vipCreated++
+	} else {
+		c.normalCreated++
+	}
+
+	c.insertPending(order)
+	c.logf("Created %s Order #%d - Status: PENDING", kind, id)
+	c.assignIdleBots()
+
+	return id
+}
+
+func (c *Controller) insertPending(order *Order) {
+	order.Status = StatusPending
+	order.CompletedAt = time.Time{}
+
+	idx := len(c.pending)
+	for i, existing := range c.pending {
+		if pendingLess(order, existing) {
+			idx = i
+			break
+		}
+	}
+
+	c.pending = append(c.pending, nil)
+	copy(c.pending[idx+1:], c.pending[idx:])
+	c.pending[idx] = order
+}
+
+func (c *Controller) assignIdleBots() {
+	for _, bot := range c.bots {
+		if bot.current != nil || len(c.pending) == 0 {
+			continue
+		}
+
+		order := c.pending[0]
+		c.pending = c.pending[1:]
+		order.Status = StatusProcessing
+		order.StartedAt = c.now
+
+		bot.current = order
+		bot.startedAt = c.now
+		c.logf("Bot #%d picked up %s Order #%d - Status: PROCESSING", bot.ID, order.Kind, order.ID)
+	}
+}
+
+func (c *Controller) nextCompletion(target time.Time) (*Bot, time.Time) {
+	var selected *Bot
+	var selectedAt time.Time
+
+	for _, bot := range c.bots {
+		if bot.current == nil {
+			continue
+		}
+
+		completedAt := bot.startedAt.Add(ProcessingDuration)
+		if completedAt.After(target) {
+			continue
+		}
+		if selected == nil || completedAt.Before(selectedAt) || completedAt.Equal(selectedAt) && bot.ID < selected.ID {
+			selected = bot
+			selectedAt = completedAt
+		}
+	}
+
+	return selected, selectedAt
+}
+
+func (c *Controller) logf(format string, args ...any) {
+	c.events = append(c.events, Event{
+		At:      c.now,
+		Message: fmt.Sprintf(format, args...),
+	})
+}
+
+func pendingLess(a, b *Order) bool {
+	if a.Kind != b.Kind {
+		return a.Kind == KindVIP
+	}
+	return a.sequence < b.sequence
+}
+
+func viewOrder(order *Order) OrderView {
+	return OrderView{
+		ID:     order.ID,
+		Kind:   order.Kind,
+		Status: order.Status,
+	}
+}

--- a/internal/order/controller_test.go
+++ b/internal/order/controller_test.go
@@ -1,0 +1,111 @@
+package order
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestVIPOrdersAreQueuedBeforeNormalOrders(t *testing.T) {
+	controller := NewController(testStart())
+
+	normal1 := controller.AddNormalOrder()
+	vip1 := controller.AddVIPOrder()
+	normal2 := controller.AddNormalOrder()
+	vip2 := controller.AddVIPOrder()
+
+	got := orderIDs(controller.Snapshot().Pending)
+	want := []int{vip1, vip2, normal1, normal2}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("pending order ids = %v, want %v", got, want)
+	}
+}
+
+func TestBotCompletesOrdersAfterTenSeconds(t *testing.T) {
+	controller := NewController(testStart())
+
+	first := controller.AddVIPOrder()
+	second := controller.AddNormalOrder()
+	controller.AddBot()
+
+	controller.Advance(9 * time.Second)
+	if got := len(controller.Snapshot().Completed); got != 0 {
+		t.Fatalf("completed before 10 seconds = %d, want 0", got)
+	}
+
+	controller.Advance(1 * time.Second)
+	snapshot := controller.Snapshot()
+	if got, want := orderIDs(snapshot.Completed), []int{first}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("completed after 10 seconds = %v, want %v", got, want)
+	}
+	if got, want := processingIDs(snapshot.Processing), []int{second}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("processing after first completion = %v, want %v", got, want)
+	}
+
+	controller.Advance(10 * time.Second)
+	snapshot = controller.Snapshot()
+	if got, want := orderIDs(snapshot.Completed), []int{first, second}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("completed after second 10 seconds = %v, want %v", got, want)
+	}
+	if got := len(snapshot.IdleBots); got != 1 {
+		t.Fatalf("idle bots = %d, want 1", got)
+	}
+}
+
+func TestDestroyNewestProcessingBotReturnsOrderToPriorityPosition(t *testing.T) {
+	controller := NewController(testStart())
+
+	normal1 := controller.AddNormalOrder()
+	normal2 := controller.AddNormalOrder()
+	controller.AddBot()
+	controller.AddBot()
+	vip := controller.AddVIPOrder()
+
+	removed, ok := controller.RemoveBot()
+	if !ok || removed != 2 {
+		t.Fatalf("removed bot = (%d, %v), want (2, true)", removed, ok)
+	}
+
+	snapshot := controller.Snapshot()
+	if got, want := processingIDs(snapshot.Processing), []int{normal1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("processing orders = %v, want %v", got, want)
+	}
+	if got, want := orderIDs(snapshot.Pending), []int{vip, normal2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pending order ids after bot destroy = %v, want %v", got, want)
+	}
+}
+
+func TestIdleBotImmediatelyPicksNewOrder(t *testing.T) {
+	controller := NewController(testStart())
+
+	controller.AddBot()
+	orderID := controller.AddVIPOrder()
+
+	snapshot := controller.Snapshot()
+	if got := len(snapshot.Pending); got != 0 {
+		t.Fatalf("pending orders = %d, want 0", got)
+	}
+	if got, want := processingIDs(snapshot.Processing), []int{orderID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("processing orders = %v, want %v", got, want)
+	}
+}
+
+func testStart() time.Time {
+	return time.Date(2026, 7, 2, 8, 0, 0, 0, time.UTC)
+}
+
+func orderIDs(orders []OrderView) []int {
+	ids := make([]int, 0, len(orders))
+	for _, order := range orders {
+		ids = append(ids, order.ID)
+	}
+	return ids
+}
+
+func processingIDs(orders []ProcessingView) []int {
+	ids := make([]int, 0, len(orders))
+	for _, order := range orders {
+		ids = append(ids, order.OrderID)
+	}
+	return ids
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,15 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Build Script
-# This script should contain all compilation steps for your CLI application
+set -euo pipefail
 
 echo "Building CLI application..."
 
-# For Go projects:
-# go build -o order-controller ./cmd/main.go
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
-# For Node.js projects:
-# npm install
-# npm run build (if needed)
+cd "${ROOT_DIR}"
+mkdir -p "${ROOT_DIR}/bin"
+export GOCACHE="${GOCACHE:-/tmp/se-take-home-go-cache}"
+
+go build -o "${ROOT_DIR}/bin/order-controller" ./cmd/order-controller
 
 echo "Build completed"

--- a/scripts/result.txt
+++ b/scripts/result.txt
@@ -1,26 +1,28 @@
-McDonald's Order Management System - Simulation Results
-
-[14:32:01] System initialized with 0 bots
-[14:32:01] Created Normal Order #1001 - Status: PENDING
-[14:32:02] Created VIP Order #1002 - Status: PENDING
-[14:32:02] Created Normal Order #1003 - Status: PENDING
-[14:32:03] Bot #1 created - Status: ACTIVE
-[14:32:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
-[14:32:04] Bot #2 created - Status: ACTIVE
-[14:32:04] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
-[14:32:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
-[14:32:13] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
-[14:32:14] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
-[14:32:14] Bot #2 is now IDLE - No pending orders
-[14:32:15] Created VIP Order #1004 - Status: PENDING
-[14:32:15] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
-[14:32:23] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 destroyed while IDLE
-[14:32:26] Bot #1 is now IDLE - No pending orders
-
-Final Status:
-- Total Orders Processed: 4 (2 VIP, 2 Normal)
-- Orders Completed: 4
-- Active Bots: 1
-- Pending Orders: 0
+[08:00:00] McDonald's Order Management System - Simulation Results
+[08:00:00] System initialized with 0 bots
+[08:00:00] Created Normal Order #1001 - Status: PENDING
+[08:00:01] Created VIP Order #1002 - Status: PENDING
+[08:00:02] Created Normal Order #1003 - Status: PENDING
+[08:00:03] Bot #1 created - Status: IDLE
+[08:00:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
+[08:00:04] Bot #2 created - Status: IDLE
+[08:00:04] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
+[08:00:08] Bot #2 destroyed while processing Normal Order #1001 - Order returned to PENDING
+[08:00:08] Created VIP Order #1004 - Status: PENDING
+[08:00:08] Bot #3 created - Status: IDLE
+[08:00:08] Bot #3 picked up VIP Order #1004 - Status: PROCESSING
+[08:00:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
+[08:00:13] Bot #1 picked up Normal Order #1001 - Status: PROCESSING
+[08:00:18] Bot #3 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
+[08:00:18] Bot #3 picked up Normal Order #1003 - Status: PROCESSING
+[08:00:23] Bot #1 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
+[08:00:23] Bot #1 is now IDLE - No pending orders
+[08:00:28] Bot #3 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
+[08:00:28] Bot #3 is now IDLE - No pending orders
+[08:00:28] Bot #3 destroyed while IDLE
+[08:00:28] Final Status: Orders Created=4 (2 VIP, 2 Normal)
+[08:00:28] Final Status: Orders Completed=4
+[08:00:28] Final Status: Active Bots=1, Pending=0, Processing=0
+[08:00:28] Pending Queue: []
+[08:00:28] Processing Orders: []
+[08:00:28] Complete Orders: [VIP#1002, VIP#1004, Normal#1001, Normal#1003]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,19 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Run Script
-# This script should execute your CLI application and output results to result.txt
+set -euo pipefail
 
 echo "Running CLI application..."
 
-# For Go projects:
-# ./order-controller > result.txt
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
-# For Node.js projects:
-# node index.js > result.txt
-# or npm start > result.txt
+if [ ! -x "${ROOT_DIR}/bin/order-controller" ]; then
+  "${SCRIPT_DIR}/build.sh"
+fi
 
-# Temporary placeholder - remove this when you implement your CLI
-echo "Added 1 bot" > result.txt
-echo "status: bot: [1], order: []" >> result.txt
+"${ROOT_DIR}/bin/order-controller" run > "${SCRIPT_DIR}/result.txt"
 
 echo "CLI application execution completed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,14 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Unit Test Script
-# This script should contain all unit test execution steps
+set -euo pipefail
 
 echo "Running unit tests..."
 
-# For Go projects:
-# go test ./... -v
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
-# For Node.js projects:
-# npm test
+cd "${ROOT_DIR}"
+export GOCACHE="${GOCACHE:-/tmp/se-take-home-go-cache}"
+
+go test ./...
 
 echo "Unit tests completed"


### PR DESCRIPTION
Add an in-memory order controller for the backend take-home assignment with VIP priority queuing, bot lifecycle handling, simulated 10-second processing, and order completion reporting.

Add a Go CLI with demo and interactive modes, wire the required test/build/run scripts to the implementation, and generate timestamped output in scripts/result.txt. Document script usage and interactive commands in README.