### PR TITLE
feat: Node.js CLI order controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,64 @@ You must implement **either** frontend or backend components as described below:
 - Testing, testing and testing. Make sure the prototype is functioning and meeting all the requirements.
 - Utilize coding agent to complete the assignment scope your working hour within 1 hour, do not over engineer it. However, ensure you read and understand what your code doing and apply good engineering practice.
 - Complete the implementation as clean as possible, clean code is a strong plus point, do not bring in all the fancy tech stuff.
+
+
+---
+
+## Solution — Backend (Node.js CLI)
+
+A McDonald's cooking-bot order controller implemented as a Node.js CLI with
+**no third-party dependencies** — only Node.js built-ins (`node:test`,
+`node:readline`). Requires Node.js >= 18 (CI uses 22.19.0).
+
+### Project structure
+| Path | Purpose |
+|------|---------|
+| `src/OrderController.js` | Core state machine: orders, bots, priority queue, scheduling |
+| `src/constants.js` | Shared constants (10s process time, order types, statuses) |
+| `src/virtualClock.js` | Deterministic scheduler + clock used by tests and the simulation |
+| `src/index.js` | Scripted, non-interactive scenario → timestamped output |
+| `bin/cli.js` | Interactive REPL (real 10-second timers) |
+| `test/OrderController.test.js` | Unit tests (Node built-in test runner) |
+| `scripts/{build,test,run}.sh` | CI entry points |
+
+### Running
+
+**Simulation** (default; instant, writes a timestamped event log — used by CI):
+```
+npm start             # runs src/index.js, prints to stdout
+./scripts/run.sh      # same, but writes to scripts/result.txt
+```
+
+**Interactive mode** (for the live demo — each order takes a real 10 seconds):
+```
+npm run cli           # runs bin/cli.js
+```
+Commands: `normal`, `vip`, `+bot`, `-bot`, `status`, `help`, `exit`.
+
+**Tests:**
+```
+npm test              # or ./scripts/test.sh
+```
+
+### Design decisions
+- **Single sorted PENDING queue.** Orders are kept sorted by
+  `(type rank, order number)` — VIP outranks Normal, FIFO within a type. This
+  makes VIP placement (req #2) and returning an interrupted order to its
+  original position (req #6) fall out of one invariant.
+- **Time is injected.** `OrderController` receives a `scheduler` and a `now()`
+  clock instead of calling `setTimeout` directly. The interactive CLI injects
+  real timers; the simulation and tests inject a virtual clock — so tests are
+  instant and deterministic, CI finishes in under a second, and the output
+  still shows realistic 10-second gaps in `HH:MM:SS`.
+- **Event-driven output.** The controller emits timestamped events via an
+  `onEvent` callback; the CLI and simulation only format them.
+
+### Requirement coverage
+1. New Normal order → PENDING
+2. New VIP order → ahead of Normal, behind existing VIP
+3. Unique, increasing order numbers
+4. `+Bot` processes immediately; 10s → COMPLETE; then picks next
+5. Bot goes IDLE when the queue is empty
+6. `-Bot` removes newest; if processing, order returns to its position
+7. In-memory only, no persistence

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Interactive CLI for the McDonald's order controller.
+// Uses real wall-clock timers (default scheduler) so each order takes 10s.
+import readline from 'node:readline';
+import { OrderController } from '../src/OrderController.js';
+
+function formatTime(ms) {
+  return new Date(ms).toTimeString().slice(0, 8); // HH:MM:SS
+}
+
+const controller = new OrderController({
+  onEvent: (msg, ms) => console.log(`[${formatTime(ms)}] ${msg}`),
+});
+
+function printStatus() {
+  const snap = controller.snapshot();
+  const fmtOrder = (o) => `${o.type === 'VIP' ? 'V' : 'N'}#${o.number}`;
+  const fmtBot = (b) =>
+    `#${b.id}:${b.status}${b.order ? `(${fmtOrder(b.order)})` : ''}`;
+  console.log('--- STATUS ---');
+  console.log('PENDING :', snap.pending.map(fmtOrder).join(', ') || '(none)');
+  console.log('BOTS    :', snap.bots.map(fmtBot).join(', ') || '(none)');
+  console.log('COMPLETE:', snap.completed.map(fmtOrder).join(', ') || '(none)');
+  console.log('--------------');
+}
+
+const HELP = `Commands:
+  normal    Create a new Normal order
+  vip       Create a new VIP order
+  +bot      Add a cooking bot
+  -bot      Remove the newest cooking bot
+  status    Show PENDING / BOTS / COMPLETE
+  help      Show this help
+  exit      Quit`;
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: '> ',
+});
+
+console.log("McDonald's Order Controller (interactive) - each order takes 10s.");
+console.log(HELP);
+rl.prompt();
+
+rl.on('line', (line) => {
+  const cmd = line.trim().toLowerCase();
+  switch (cmd) {
+    case 'normal':
+      controller.newNormalOrder();
+      break;
+    case 'vip':
+      controller.newVipOrder();
+      break;
+    case '+bot':
+      controller.addBot();
+      break;
+    case '-bot':
+      controller.removeBot();
+      break;
+    case 'status':
+      printStatus();
+      break;
+    case 'help':
+      console.log(HELP);
+      break;
+    case 'exit':
+    case 'quit':
+      rl.close();
+      return;
+    case '':
+      break;
+    default:
+      console.log(`Unknown command: "${cmd}". Type "help" for commands.`);
+  }
+  rl.prompt();
+});
+
+rl.on('close', () => {
+  console.log('Goodbye.');
+  process.exit(0);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "mcdonalds-order-controller",
+    "version": "1.0.0",
+    "type": "module",
+    "engines": {
+        "node": ">=18"
+    },
+    "scripts": {
+        "start": "node src/index.js",
+        "cli": "node bin/cli.js",
+        "test": "node --test"
+    },
+    "license": "MIT"
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
-
-# Build Script
-# This script should contain all compilation steps for your CLI application
+# Build script: prepare the CLI application.
+set -e
+cd "$(dirname "$0")/.."
 
 echo "Building CLI application..."
 
-# For Go projects:
-# go build -o order-controller ./cmd/main.go
+# Ensure Node.js is available before doing anything else.
+if ! command -v node > /dev/null 2>&1; then
+  echo "ERROR: Node.js is not installed or not on PATH. Please install Node.js >= 18." >&2
+  exit 1
+fi
+echo "Using Node.js $(node --version)"
 
-# For Node.js projects:
-# npm install
-# npm run build (if needed)
+# No third-party dependencies to install (uses only Node.js built-ins).
+# Syntax-check the entry points to catch errors before running.
+node --check src/OrderController.js
+node --check src/virtualClock.js
+node --check src/index.js
+node --check bin/cli.js
 
 echo "Build completed"

--- a/scripts/result.txt
+++ b/scripts/result.txt
@@ -1,26 +1,75 @@
 McDonald's Order Management System - Simulation Results
+Legend: V#=VIP order, N#=Normal order | STATUS shows state AFTER each step
 
-[14:32:01] System initialized with 0 bots
-[14:32:01] Created Normal Order #1001 - Status: PENDING
-[14:32:02] Created VIP Order #1002 - Status: PENDING
-[14:32:02] Created Normal Order #1003 - Status: PENDING
-[14:32:03] Bot #1 created - Status: ACTIVE
-[14:32:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
-[14:32:04] Bot #2 created - Status: ACTIVE
-[14:32:04] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
-[14:32:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
-[14:32:13] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
-[14:32:14] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
-[14:32:14] Bot #2 is now IDLE - No pending orders
-[14:32:15] Created VIP Order #1004 - Status: PENDING
-[14:32:15] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
-[14:32:23] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 destroyed while IDLE
-[14:32:26] Bot #1 is now IDLE - No pending orders
+>> System starts with 0 bots
+[09:00:00] System initialized
+   PENDING : (none)
+   BOTS    : (none)
+   COMPLETE: (none)
 
-Final Status:
-- Total Orders Processed: 4 (2 VIP, 2 Normal)
-- Orders Completed: 4
+>> Customer places a Normal order
+[09:00:01] Created Normal Order #1001 - Status: PENDING
+   PENDING : N#1001
+   BOTS    : (none)
+   COMPLETE: (none)
+
+>> VIP places an order (jumps ahead of the Normal order)
+[09:00:02] Created VIP Order #1002 - Status: PENDING
+   PENDING : V#1002, N#1001
+   BOTS    : (none)
+   COMPLETE: (none)
+
+>> Another Normal order arrives
+[09:00:03] Created Normal Order #1003 - Status: PENDING
+   PENDING : V#1002, N#1001, N#1003
+   BOTS    : (none)
+   COMPLETE: (none)
+
+>> Manager adds Bot #1 (immediately grabs the VIP order)
+[09:00:03] Bot #1 created - Status: IDLE
+[09:00:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
+   PENDING : N#1001, N#1003
+   BOTS    : #1 PROCESSING -> V#1002
+   COMPLETE: (none)
+
+>> Manager adds Bot #2 (grabs the next order)
+[09:00:03] Bot #2 created - Status: IDLE
+[09:00:03] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
+   PENDING : N#1003
+   BOTS    : #1 PROCESSING -> V#1002 | #2 PROCESSING -> N#1001
+   COMPLETE: (none)
+
+>> A new VIP order arrives while both bots are busy
+[09:00:04] Created VIP Order #1004 - Status: PENDING
+   PENDING : V#1004, N#1003
+   BOTS    : #1 PROCESSING -> V#1002 | #2 PROCESSING -> N#1001
+   COMPLETE: (none)
+
+>> 10 seconds pass — bots finish and pick up the next orders
+[09:00:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
+[09:00:13] Bot #1 picked up VIP Order #1004 - Status: PROCESSING
+[09:00:13] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
+[09:00:13] Bot #2 picked up Normal Order #1003 - Status: PROCESSING
+   PENDING : (none)
+   BOTS    : #1 PROCESSING -> V#1004 | #2 PROCESSING -> N#1003
+   COMPLETE: V#1002, N#1001
+
+>> Manager removes the newest bot mid-cook (order returns to queue)
+[09:00:14] Bot #2 destroyed while processing - Normal Order #1003 returned to PENDING
+   PENDING : N#1003
+   BOTS    : #1 PROCESSING -> V#1004
+   COMPLETE: V#1002, N#1001
+
+>> Time passes — remaining bot drains the queue
+[09:00:23] Bot #1 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
+[09:00:23] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
+[09:00:33] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
+[09:00:33] Bot #1 is now IDLE - No pending orders
+   PENDING : (none)
+   BOTS    : #1 IDLE
+   COMPLETE: V#1002, N#1001, V#1004, N#1003
+
+Final Summary:
+- Orders Completed: 4 (2 VIP, 2 Normal)
 - Active Bots: 1
 - Pending Orders: 0

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
-
-# Run Script
-# This script should execute your CLI application and output results to result.txt
+# Run script: execute the simulation and write timestamped output to result.txt.
+set -e
+cd "$(dirname "$0")/.."
 
 echo "Running CLI application..."
-
-# For Go projects:
-# ./order-controller > result.txt
-
-# For Node.js projects:
-# node index.js > result.txt
-# or npm start > result.txt
-
-# Temporary placeholder - remove this when you implement your CLI
-echo "Added 1 bot" > result.txt
-echo "status: bot: [1], order: []" >> result.txt
-
+node src/index.js > scripts/result.txt
 echo "CLI application execution completed"
+
+echo "----- result.txt -----"
+cat scripts/result.txt

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
-
-# Unit Test Script
-# This script should contain all unit test execution steps
+# Test script: run the unit test suite.
+set -e
+cd "$(dirname "$0")/.."
 
 echo "Running unit tests..."
-
-# For Go projects:
-# go test ./... -v
-
-# For Node.js projects:
-# npm test
-
+npm test
 echo "Unit tests completed"

--- a/src/OrderController.js
+++ b/src/OrderController.js
@@ -1,0 +1,186 @@
+// Core order-controller state machine.
+//
+// Design notes:
+// - PENDING orders are always kept sorted by (type rank, order number),
+//   so VIP-before-Normal + FIFO-within-type is an invariant of the list.
+//   This makes requirement #2 (VIP placement) and requirement #6 (returning
+//   an interrupted order to its original position) fall out automatically.
+// - Time is injected (scheduler + clock) so the logic is deterministic and
+//   testable: real timers drive the interactive CLI, a virtual clock drives
+//   the simulation and unit tests.
+
+import {
+  PROCESS_MS,
+  OrderType,
+  TYPE_RANK,
+  OrderStatus,
+  BotStatus,
+} from './constants.js';
+
+// Default scheduler backed by real wall-clock timers (used by the CLI).
+const realScheduler = {
+  schedule: (ms, cb) => setTimeout(cb, ms),
+  cancel: (id) => clearTimeout(id),
+};
+
+export class OrderController {
+  /**
+   * @param {object}   [options]
+   * @param {object}   [options.scheduler] - { schedule(ms, cb) -> id, cancel(id) }
+   * @param {function} [options.now]        - returns current time in ms
+   * @param {function} [options.onEvent]    - (message, timestampMs) => void
+   */
+  constructor({ scheduler = realScheduler, now = Date.now, onEvent } = {}) {
+    this.scheduler = scheduler;
+    this.now = now;
+    this.onEvent = onEvent ?? (() => {});
+
+    this.pending = [];    // sorted queue of PENDING orders
+    this.completed = [];  // COMPLETE orders, in completion order
+    this.bots = [];       // active bots, oldest first (newest at the end)
+
+    this.nextOrderNumber = 1001; // unique, increasing
+    this.nextBotId = 1;          // unique, increasing
+  }
+
+  // --- Event logging -------------------------------------------------------
+
+  #emit(message) {
+    this.onEvent(message, this.now());
+  }
+
+  // --- Orders --------------------------------------------------------------
+
+  newNormalOrder() {
+    return this.#addOrder(OrderType.NORMAL);
+  }
+
+  newVipOrder() {
+    return this.#addOrder(OrderType.VIP);
+  }
+
+  #addOrder(type) {
+    const order = {
+      number: this.nextOrderNumber++,
+      type,
+      status: OrderStatus.PENDING,
+    };
+    this.#enqueue(order);
+    this.#emit(`Created ${type} Order #${order.number} - Status: PENDING`);
+    this.#assignIdleBots();
+    return order;
+  }
+
+  // Insert into PENDING keeping the (type rank, order number) ordering.
+  #enqueue(order) {
+    order.status = OrderStatus.PENDING;
+    const rank = TYPE_RANK[order.type];
+    let i = this.pending.length;
+    while (
+      i > 0 &&
+      (TYPE_RANK[this.pending[i - 1].type] > rank ||
+        (TYPE_RANK[this.pending[i - 1].type] === rank &&
+          this.pending[i - 1].number > order.number))
+    ) {
+      i--;
+    }
+    this.pending.splice(i, 0, order);
+  }
+
+  // --- Bots ----------------------------------------------------------------
+
+  addBot() {
+    const bot = {
+      id: this.nextBotId++,
+      status: BotStatus.IDLE,
+      order: null,
+      timerId: null,
+    };
+    this.bots.push(bot);
+    this.#emit(`Bot #${bot.id} created - Status: IDLE`);
+    this.#assignIdleBots();
+    return bot;
+  }
+
+  // Requirement #6: remove the newest bot. If it was processing, cancel the
+  // work and return the order to its original position in PENDING.
+  removeBot() {
+    const bot = this.bots.pop();
+    if (!bot) return null;
+
+    if (bot.status === BotStatus.PROCESSING && bot.order) {
+      this.scheduler.cancel(bot.timerId);
+      const order = bot.order;
+      bot.order = null;
+      bot.timerId = null;
+      this.#enqueue(order); // drops back into its correct slot
+      this.#emit(
+        `Bot #${bot.id} destroyed while processing - ` +
+          `${order.type} Order #${order.number} returned to PENDING`,
+      );
+      // A remaining idle bot may now pick up the returned order.
+      this.#assignIdleBots();
+    } else {
+      this.#emit(`Bot #${bot.id} destroyed while IDLE`);
+    }
+    return bot;
+  }
+
+  // --- Scheduling ----------------------------------------------------------
+
+  // Give pending orders to any idle bots (front of queue first).
+  #assignIdleBots() {
+    for (const bot of this.bots) {
+      if (bot.status === BotStatus.IDLE && this.pending.length > 0) {
+        this.#startProcessing(bot);
+      }
+    }
+  }
+
+  #startProcessing(bot) {
+    const order = this.pending.shift();
+    order.status = OrderStatus.PROCESSING;
+    bot.order = order;
+    bot.status = BotStatus.PROCESSING;
+    this.#emit(
+      `Bot #${bot.id} picked up ${order.type} Order #${order.number} - ` +
+        `Status: PROCESSING`,
+    );
+    bot.timerId = this.scheduler.schedule(PROCESS_MS, () =>
+      this.#completeOrder(bot),
+    );
+  }
+
+  #completeOrder(bot) {
+    const order = bot.order;
+    order.status = OrderStatus.COMPLETE;
+    this.completed.push(order);
+    bot.order = null;
+    bot.timerId = null;
+    bot.status = BotStatus.IDLE;
+    this.#emit(
+      `Bot #${bot.id} completed ${order.type} Order #${order.number} - ` +
+        `Status: COMPLETE (Processing time: ${PROCESS_MS / 1000}s)`,
+    );
+
+    if (this.pending.length > 0) {
+      this.#startProcessing(bot);
+    } else {
+      this.#emit(`Bot #${bot.id} is now IDLE - No pending orders`);
+    }
+  }
+
+  // --- Snapshot (for status display) --------------------------------------
+
+  snapshot() {
+    return {
+      pending: this.pending.map((o) => ({ ...o })),
+      completed: this.completed.map((o) => ({ ...o })),
+      bots: this.bots.map((b) => ({
+        id: b.id,
+        status: b.status,
+        order: b.order ? { ...b.order } : null,
+      })),
+    };
+  }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,33 @@
+// Shared constants for the order controller.
+
+// Object freeze to prevent accidental mutation of these constants at runtime.
+
+// Time (in milliseconds) a bot takes to process one order.
+// Requirement #4: each order requires 10 seconds to complete.
+export const PROCESS_MS = 10_000;
+
+// Order types. Lower rank = higher priority in the PENDING queue.
+// Requirement #2: VIP orders are processed before Normal orders.
+export const OrderType = Object.freeze({
+  VIP: 'VIP',
+  NORMAL: 'Normal',
+});
+
+// Priority rank per type: VIP (0) sorts ahead of Normal (1).
+export const TYPE_RANK = Object.freeze({
+  [OrderType.VIP]: 0,
+  [OrderType.NORMAL]: 1,
+});
+
+// Order lifecycle states.
+export const OrderStatus = Object.freeze({
+  PENDING: 'PENDING',
+  PROCESSING: 'PROCESSING',
+  COMPLETE: 'COMPLETE',
+});
+
+// Bot states.
+export const BotStatus = Object.freeze({
+  IDLE: 'IDLE',
+  PROCESSING: 'PROCESSING',
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,110 @@
+// Scripted, non-interactive scenario that exercises every requirement.
+// After each action it prints a STATUS snapshot (pending queue, what each bot
+// is cooking, and completed orders) so the whole system state is visible —
+// not just the event that was triggered. Driven by a virtual clock, so it runs
+// instantly while still showing realistic 10s gaps in HH:MM:SS.
+import { OrderController } from './OrderController.js';
+import { createVirtualClock } from './virtualClock.js';
+
+// Anchor the clock at 09:00:00 for readable, deterministic timestamps.
+const BASE_MS = 9 * 3600 * 1000;
+
+function formatTime(ms) {
+  const total = Math.floor((BASE_MS + ms) / 1000);
+  const hh = String(Math.floor(total / 3600) % 24).padStart(2, '0');
+  const mm = String(Math.floor(total / 60) % 60).padStart(2, '0');
+  const ss = String(total % 60).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}
+
+function main() {
+  const clock = createVirtualClock();
+  const lines = [
+    "McDonald's Order Management System - Simulation Results",
+    'Legend: V#=VIP order, N#=Normal order | STATUS shows state AFTER each step',
+    '',
+  ];
+  const log = (msg, ms) => lines.push(`[${formatTime(ms)}] ${msg}`);
+
+  const controller = new OrderController({
+    scheduler: clock.scheduler,
+    now: clock.now,
+    onEvent: log,
+  });
+
+  const fmtOrder = (o) => `${o.type === 'VIP' ? 'V' : 'N'}#${o.number}`;
+  const fmtBot = (b) =>
+    `#${b.id} ${b.status}${b.order ? ` -> ${fmtOrder(b.order)}` : ''}`;
+
+  // Print the current state after a step.
+  function status() {
+    const s = controller.snapshot();
+    lines.push(`   PENDING : ${s.pending.map(fmtOrder).join(', ') || '(none)'}`);
+    lines.push(`   BOTS    : ${s.bots.map(fmtBot).join(' | ') || '(none)'}`);
+    lines.push(`   COMPLETE: ${s.completed.map(fmtOrder).join(', ') || '(none)'}`);
+    lines.push('');
+  }
+
+  // Run a labelled step, then show the resulting state.
+  function step(label, fn) {
+    lines.push(`>> ${label}`);
+    fn();
+    status();
+  }
+
+  step('System starts with 0 bots', () => {
+    log('System initialized', clock.now());
+  });
+
+  step('Customer places a Normal order', () => {
+    clock.advance(1000);
+    controller.newNormalOrder(); // #1001
+  });
+
+  step('VIP places an order (jumps ahead of the Normal order)', () => {
+    clock.advance(1000);
+    controller.newVipOrder(); // #1002
+  });
+
+  step('Another Normal order arrives', () => {
+    clock.advance(1000);
+    controller.newNormalOrder(); // #1003
+  });
+
+  step('Manager adds Bot #1 (immediately grabs the VIP order)', () => {
+    controller.addBot();
+  });
+
+  step('Manager adds Bot #2 (grabs the next order)', () => {
+    controller.addBot();
+  });
+
+  step('A new VIP order arrives while both bots are busy', () => {
+    clock.advance(1000);
+    controller.newVipOrder(); // #1004
+  });
+
+  step('10 seconds pass — bots finish and pick up the next orders', () => {
+    clock.advance(10_000);
+  });
+
+  step('Manager removes the newest bot mid-cook (order returns to queue)', () => {
+    controller.removeBot();
+  });
+
+  step('Time passes — remaining bot drains the queue', () => {
+    clock.advance(20_000);
+  });
+
+  const snap = controller.snapshot();
+  const vip = snap.completed.filter((o) => o.type === 'VIP').length;
+  const normal = snap.completed.length - vip;
+  lines.push('Final Summary:');
+  lines.push(`- Orders Completed: ${snap.completed.length} (${vip} VIP, ${normal} Normal)`);
+  lines.push(`- Active Bots: ${snap.bots.length}`);
+  lines.push(`- Pending Orders: ${snap.pending.length}`);
+
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+main();

--- a/src/virtualClock.js
+++ b/src/virtualClock.js
@@ -1,0 +1,41 @@
+// A deterministic, in-memory scheduler + clock used by the simulation and the
+// unit tests. Timers fire only when advance() is called, so nothing waits on
+// real wall-clock time.
+export function createVirtualClock() {
+  let currentMs = 0;
+  let nextId = 1;
+  const tasks = [];
+
+  const scheduler = {
+    schedule(ms, cb) {
+      const id = nextId++;
+      tasks.push({ id, time: currentMs + ms, cb, active: true });
+      return id;
+    },
+    cancel(id) {
+      const task = tasks.find((t) => t.id === id);
+      if (task) task.active = false;
+    },
+  };
+
+  const now = () => currentMs;
+
+  // Advance virtual time by `ms`, firing due timers in chronological order.
+  // Re-scans after each timer so cascading work (a completion scheduling the
+  // next order) is handled correctly.
+  function advance(ms) {
+    const target = currentMs + ms;
+    for (;;) {
+      const due = tasks
+        .filter((t) => t.active && t.time <= target)
+        .sort((a, b) => a.time - b.time)[0];
+      if (!due) break;
+      due.active = false;
+      currentMs = due.time;
+      due.cb();
+    }
+    currentMs = target;
+  }
+
+  return { scheduler, now, advance };
+}

--- a/test/OrderController.test.js
+++ b/test/OrderController.test.js
@@ -1,0 +1,136 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OrderController } from '../src/OrderController.js';
+import { OrderType, OrderStatus, BotStatus, PROCESS_MS } from '../src/constants.js';
+import { createVirtualClock } from '../src/virtualClock.js';
+
+function makeController() {
+  const clock = createVirtualClock();
+  const controller = new OrderController({
+    scheduler: clock.scheduler,
+    now: clock.now,
+  });
+  return { controller, advance: clock.advance };
+}
+
+// Requirement #1: new normal order lands in PENDING.
+test('new normal order appears in PENDING', () => {
+  const { controller } = makeController();
+  const order = controller.newNormalOrder();
+  assert.equal(order.type, OrderType.NORMAL);
+  assert.equal(order.status, OrderStatus.PENDING);
+  assert.deepEqual(
+    controller.snapshot().pending.map((o) => o.number),
+    [1001],
+  );
+});
+
+// Requirement #3: order numbers are unique and increasing.
+test('order numbers are unique and increasing', () => {
+  const { controller } = makeController();
+  const a = controller.newNormalOrder();
+  const b = controller.newVipOrder();
+  const c = controller.newNormalOrder();
+  assert.deepEqual([a.number, b.number, c.number], [1001, 1002, 1003]);
+});
+
+// Requirement #2: VIP sits ahead of Normal but behind existing VIPs.
+test('VIP order queues ahead of Normal, behind existing VIP', () => {
+  const { controller } = makeController();
+  controller.newNormalOrder(); // #1001 Normal
+  controller.newVipOrder();    // #1002 VIP
+  controller.newNormalOrder(); // #1003 Normal
+  controller.newVipOrder();    // #1004 VIP
+
+  // Expected PENDING order: VIP#1002, VIP#1004, Normal#1001, Normal#1003
+  assert.deepEqual(
+    controller.snapshot().pending.map((o) => o.number),
+    [1002, 1004, 1001, 1003],
+  );
+});
+
+// Requirement #4: adding a bot immediately starts processing the front order.
+test('adding a bot starts processing the front pending order', () => {
+  const { controller } = makeController();
+  controller.newNormalOrder(); // #1001
+  controller.newVipOrder();    // #1002 (front)
+  const bot = controller.addBot();
+
+  assert.equal(bot.status, BotStatus.PROCESSING);
+  assert.equal(bot.order.number, 1002); // VIP picked first
+  assert.equal(controller.snapshot().pending.length, 1);
+});
+
+// Requirement #4: order completes after 10s and bot picks the next one.
+test('order completes after PROCESS_MS and bot continues', () => {
+  const { controller, advance } = makeController();
+  controller.newVipOrder();    // #1001
+  controller.newNormalOrder(); // #1002
+  controller.addBot();
+
+  advance(PROCESS_MS);
+  let snap = controller.snapshot();
+  assert.deepEqual(snap.completed.map((o) => o.number), [1001]);
+  assert.equal(snap.bots[0].order.number, 1002); // moved on to next
+
+  advance(PROCESS_MS);
+  snap = controller.snapshot();
+  assert.deepEqual(snap.completed.map((o) => o.number), [1001, 1002]);
+});
+
+// Requirement #5: bot goes IDLE when there is nothing left to process.
+test('bot becomes IDLE when no pending orders remain', () => {
+  const { controller, advance } = makeController();
+  controller.newNormalOrder();
+  controller.addBot();
+  advance(PROCESS_MS);
+
+  const snap = controller.snapshot();
+  assert.equal(snap.bots[0].status, BotStatus.IDLE);
+  assert.equal(snap.bots[0].order, null);
+  assert.equal(snap.pending.length, 0);
+});
+
+// Requirement #6: removing a busy bot returns its order to the right spot.
+test('removing a processing bot returns the order to PENDING in order', () => {
+  const { controller } = makeController();
+  controller.newVipOrder();    // #1001 VIP
+  controller.newNormalOrder(); // #1002 Normal
+  const bot = controller.addBot(); // starts VIP #1001
+
+  assert.equal(bot.order.number, 1001);
+
+  controller.removeBot(); // destroy the busy bot
+
+  // #1001 (VIP) must return AHEAD of #1002 (Normal).
+  assert.deepEqual(
+    controller.snapshot().pending.map((o) => o.number),
+    [1001, 1002],
+  );
+  assert.equal(controller.snapshot().bots.length, 0);
+});
+
+// Requirement #6: a remaining bot picks up the returned order.
+test('returned order is picked up by a remaining bot', () => {
+  const { controller } = makeController();
+  controller.newVipOrder(); // #1001
+  controller.addBot();      // bot #1 -> processing #1001
+  controller.addBot();      // bot #2 -> idle (nothing else pending)
+
+  controller.removeBot();   // removes newest (bot #2, idle) -> no effect on order
+  assert.equal(controller.snapshot().bots.length, 1);
+  assert.equal(controller.snapshot().bots[0].order.number, 1001);
+});
+
+// Removing an idle bot leaves orders untouched.
+test('removing an idle bot does not affect processing', () => {
+  const { controller } = makeController();
+  controller.newNormalOrder();
+  controller.addBot(); // busy
+  controller.addBot(); // idle
+  controller.removeBot(); // remove the idle one (newest)
+
+  const snap = controller.snapshot();
+  assert.equal(snap.bots.length, 1);
+  assert.equal(snap.bots[0].status, BotStatus.PROCESSING);
+});


### PR DESCRIPTION
Backend solution for the McDonald's cooking-bot order controller 

- Handles Normal/VIP orders with VIP priority (queued behind existing VIPs)
- Bots process one order at a time (10s each), go IDLE when the queue is empty
- +Bot / -Bot support; removing a busy bot returns its order to the queue
- Interactive CLI (`npm run cli`) and a scripted simulation (`npm start`)
- Unit tests via `npm test`; `run.sh` writes timestamped output to result.txt

All requirements covered; in-memory only, as specified.
