### PR TITLE
Backend: Node.js order controller CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/SOLUTION.md
+++ b/SOLUTION.md
@@ -1,0 +1,86 @@
+# FeedMe Software Engineer Take-Home — Backend Solution
+
+A small in-memory Node.js order controller implementing the FeedMe/McDonald's cooking-bot assignment.
+
+## Technical choice
+
+- **Node.js 22**, CommonJS, no runtime dependencies.
+- The core `OrderController` owns order priority, bot lifecycle, timers, and immutable snapshots.
+- The CLI is a thin adapter around the controller so the business logic can be tested deterministically.
+- Production processing time is fixed at **10,000 ms per order**.
+- No persistence is used, as requested by the assignment.
+
+This intentionally avoids a web framework, database, container, or extra infrastructure because none are required for the prototype.
+
+## Requirement mapping
+
+1. `normal` creates a unique increasing NORMAL order and places it in PENDING.
+2. `vip` creates a VIP order ahead of all pending NORMAL orders and behind older VIP orders.
+3. Order IDs are unique and monotonically increasing from 1.
+4. `+bot` creates a bot that immediately takes the highest-priority pending order. A real timer moves it to COMPLETE after 10 seconds, then the bot takes the next order.
+5. With no pending work, bots are IDLE and immediately pick up a later order.
+6. `-bot` removes the newest bot. If it was processing an order, its timer is cancelled and the order is reinserted using original submission order within its VIP/NORMAL priority class.
+7. All state lives in memory.
+
+## Interactive CLI
+
+```bash
+node src/cli.js
+```
+
+Commands:
+
+```text
+normal     create a normal order
+vip        create a VIP order
++bot       add a cooking bot
+-bot       remove the newest cooking bot
+status     print PENDING / COMPLETE / bot state
+help       print commands
+exit       exit the CLI
+```
+
+Every CLI output line starts with a local-time `HH:MM:SS` timestamp.
+
+## Employer scripts
+
+The repository's official `backend-verify-result` workflow executes the `scripts/` directory (plural), so the solution follows that executable acceptance contract.
+
+```bash
+./scripts/test.sh
+./scripts/build.sh
+./scripts/run.sh
+```
+
+- `test.sh` runs the Node test suite.
+- `build.sh` syntax-checks the source and stages the CLI into `dist/`.
+- `run.sh` executes a real demo with the default 10-second processing duration and writes meaningful timestamped output to `scripts/result.txt`.
+
+## Tests
+
+The suite covers:
+
+- VIP priority and FIFO within VIP/NORMAL classes;
+- unique increasing order IDs;
+- exact 10-second completion boundary using a deterministic scheduler;
+- idle bot pickup;
+- automatic next-order processing;
+- parallel bots with one order per bot;
+- removal of the newest bot;
+- cancellation of an interrupted bot timer;
+- reinsertion of an interrupted order into its original priority/FIFO position;
+- safe removal when no bot exists;
+- a real child-process interactive CLI smoke test with stdin commands and timestamp validation;
+- prompt CLI shutdown even if a bot still has an active processing timer.
+
+Run:
+
+```bash
+npm test
+```
+
+## Assumptions / ambiguity decisions
+
+- A VIP order does **not preempt** an order already being cooked; it only has priority over orders still in PENDING.
+- “Return to its original position” is interpreted as preserving the interrupted order's original submission sequence inside its priority class. This keeps VIP-before-NORMAL and FIFO stable even if new orders arrive while it is processing.
+- The assignment prose mentions a `script` directory, while the employer's actual GitHub Action invokes `scripts/test.sh`, `scripts/build.sh`, `scripts/run.sh` and checks `scripts/result.txt`; the implementation follows the workflow's `scripts/` path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "feedme-order-controller",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "feedme-order-controller",
+      "version": "1.0.0",
+      "engines": {
+        "node": ">=22"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "feedme-order-controller",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,15 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Build Script
-# This script should contain all compilation steps for your CLI application
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
 
-echo "Building CLI application..."
+rm -rf dist
+mkdir -p dist
 
-# For Go projects:
-# go build -o order-controller ./cmd/main.go
+node --check src/order-controller.js
+node --check src/cli.js
+cp src/order-controller.js src/cli.js dist/
+chmod +x dist/cli.js
 
-# For Node.js projects:
-# npm install
-# npm run build (if needed)
-
-echo "Build completed"
+echo "Build complete: dist/cli.js"

--- a/scripts/result.txt
+++ b/scripts/result.txt
@@ -1,26 +1,21 @@
-McDonald's Order Management System - Simulation Results
-
-[14:32:01] System initialized with 0 bots
-[14:32:01] Created Normal Order #1001 - Status: PENDING
-[14:32:02] Created VIP Order #1002 - Status: PENDING
-[14:32:02] Created Normal Order #1003 - Status: PENDING
-[14:32:03] Bot #1 created - Status: ACTIVE
-[14:32:03] Bot #1 picked up VIP Order #1002 - Status: PROCESSING
-[14:32:04] Bot #2 created - Status: ACTIVE
-[14:32:04] Bot #2 picked up Normal Order #1001 - Status: PROCESSING
-[14:32:13] Bot #1 completed VIP Order #1002 - Status: COMPLETE (Processing time: 10s)
-[14:32:13] Bot #1 picked up Normal Order #1003 - Status: PROCESSING
-[14:32:14] Bot #2 completed Normal Order #1001 - Status: COMPLETE (Processing time: 10s)
-[14:32:14] Bot #2 is now IDLE - No pending orders
-[14:32:15] Created VIP Order #1004 - Status: PENDING
-[14:32:15] Bot #2 picked up VIP Order #1004 - Status: PROCESSING
-[14:32:23] Bot #1 completed Normal Order #1003 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 completed VIP Order #1004 - Status: COMPLETE (Processing time: 10s)
-[14:32:25] Bot #2 destroyed while IDLE
-[14:32:26] Bot #1 is now IDLE - No pending orders
-
-Final Status:
-- Total Orders Processed: 4 (2 VIP, 2 Normal)
-- Orders Completed: 4
-- Active Bots: 1
-- Pending Orders: 0
+21:21:08 Demo start
+21:21:08 Order #1 NORMAL -> PENDING
+21:21:08 Order #2 VIP -> PENDING
+21:21:08 PENDING: [VIP #2, NORMAL #1]
+21:21:08 COMPLETE: []
+21:21:08 BOTS: []
+21:21:08 Bot #1 created
+21:21:08 Bot #1 started VIP order #2
+21:21:08 Bot #2 created
+21:21:08 Bot #2 started NORMAL order #1
+21:21:08 PENDING: []
+21:21:08 COMPLETE: []
+21:21:08 BOTS: [#1 PROCESSING order #2, #2 PROCESSING order #1]
+21:21:18 Order #2 VIP -> COMPLETE by Bot #1
+21:21:18 Bot #1 -> IDLE
+21:21:18 Order #1 NORMAL -> COMPLETE by Bot #2
+21:21:18 Bot #2 -> IDLE
+21:21:18 PENDING: []
+21:21:18 COMPLETE: [VIP #2, NORMAL #1]
+21:21:18 BOTS: [#1 IDLE, #2 IDLE]
+21:21:18 Demo complete

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,19 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Run Script
-# This script should execute your CLI application and output results to result.txt
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
 
-echo "Running CLI application..."
+if [[ ! -f dist/cli.js ]]; then
+  echo "ERROR: dist/cli.js not found. Run scripts/build.sh first." >&2
+  exit 1
+fi
 
-# For Go projects:
-# ./order-controller > result.txt
-
-# For Node.js projects:
-# node index.js > result.txt
-# or npm start > result.txt
-
-# Temporary placeholder - remove this when you implement your CLI
-echo "Added 1 bot" > result.txt
-echo "status: bot: [1], order: []" >> result.txt
-
-echo "CLI application execution completed"
+rm -f scripts/result.txt
+node dist/cli.js --demo > scripts/result.txt
+cat scripts/result.txt

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,14 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Unit Test Script
-# This script should contain all unit test execution steps
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
 
-echo "Running unit tests..."
-
-# For Go projects:
-# go test ./... -v
-
-# For Node.js projects:
-# npm test
-
-echo "Unit tests completed"
+node --version
+npm test

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+'use strict';
+
+const readline = require('node:readline');
+const { OrderController } = require('./order-controller');
+
+function timestamp(date = new Date()) {
+  const pad = (value) => String(value).padStart(2, '0');
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+function log(message) {
+  process.stdout.write(`${timestamp()} ${message}\n`);
+}
+
+function formatEvent(event) {
+  switch (event.type) {
+    case 'order-created':
+      return `Order #${event.orderId} ${event.orderType} -> PENDING`;
+    case 'bot-created':
+      return `Bot #${event.botId} created`;
+    case 'order-started':
+      return `Bot #${event.botId} started ${event.orderType} order #${event.orderId}`;
+    case 'order-completed':
+      return `Order #${event.orderId} ${event.orderType} -> COMPLETE by Bot #${event.botId}`;
+    case 'bot-idle':
+      return `Bot #${event.botId} -> IDLE`;
+    case 'order-requeued':
+      return `Order #${event.orderId} ${event.orderType} -> PENDING (Bot #${event.botId} removed)`;
+    case 'bot-removed':
+      return `Bot #${event.botId} removed`;
+    default:
+      return `Event: ${event.type}`;
+  }
+}
+
+function printSnapshot(controller) {
+  const snapshot = controller.getSnapshot();
+  const pending = snapshot.pending.map((order) => `${order.type} #${order.id}`).join(', ');
+  const complete = snapshot.complete.map((order) => `${order.type} #${order.id}`).join(', ');
+  const bots = snapshot.bots.map((bot) => {
+    if (bot.status === 'PROCESSING') return `#${bot.id} PROCESSING order #${bot.orderId}`;
+    return `#${bot.id} IDLE`;
+  }).join(', ');
+
+  log(`PENDING: [${pending}]`);
+  log(`COMPLETE: [${complete}]`);
+  log(`BOTS: [${bots}]`);
+}
+
+function createController() {
+  return new OrderController({ onEvent: (event) => log(formatEvent(event)) });
+}
+
+function handleCommand(controller, rawCommand) {
+  const command = rawCommand.trim().toLowerCase();
+  switch (command) {
+    case 'normal':
+    case 'new-normal':
+      controller.addNormalOrder();
+      return true;
+    case 'vip':
+    case 'new-vip':
+      controller.addVipOrder();
+      return true;
+    case '+bot':
+    case 'add-bot':
+      controller.addBot();
+      return true;
+    case '-bot':
+    case 'remove-bot': {
+      const removed = controller.removeBot();
+      if (!removed) log('No bot to remove');
+      return true;
+    }
+    case 'status':
+      printSnapshot(controller);
+      return true;
+    case 'help':
+      log('Commands: normal, vip, +bot, -bot, status, help, exit');
+      return true;
+    case 'exit':
+    case 'quit':
+      return false;
+    case '':
+      return true;
+    default:
+      log(`Unknown command: ${rawCommand.trim()}`);
+      log('Commands: normal, vip, +bot, -bot, status, help, exit');
+      return true;
+  }
+}
+
+async function runInteractive() {
+  const controller = createController();
+  log('FeedMe Order Controller ready. Type help for commands.');
+
+  const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!handleCommand(controller, line)) {
+      rl.close();
+      break;
+    }
+  }
+  controller.shutdown();
+}
+
+async function runDemo() {
+  const controller = createController();
+  log('Demo start');
+  controller.addNormalOrder();
+  controller.addVipOrder();
+  printSnapshot(controller);
+  controller.addBot();
+  controller.addBot();
+  printSnapshot(controller);
+  await new Promise((resolve) => setTimeout(resolve, 10_100));
+  printSnapshot(controller);
+  log('Demo complete');
+}
+
+async function main() {
+  if (process.argv.includes('--demo')) await runDemo();
+  else await runInteractive();
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    log(`Fatal error: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { formatEvent, handleCommand, printSnapshot, runDemo, runInteractive, timestamp };

--- a/src/order-controller.js
+++ b/src/order-controller.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const ORDER_TYPES = Object.freeze({
+  NORMAL: 'NORMAL',
+  VIP: 'VIP',
+});
+
+class OrderController {
+  constructor({ scheduler, processingMs = 10_000, onEvent } = {}) {
+    if (!Number.isFinite(processingMs) || processingMs <= 0) {
+      throw new TypeError('processingMs must be a positive number');
+    }
+
+    this.scheduler = scheduler ?? {
+      setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+      clearTimeout: (timerId) => clearTimeout(timerId),
+    };
+    this.processingMs = processingMs;
+    this.onEvent = typeof onEvent === 'function' ? onEvent : () => {};
+
+    this.nextOrderId = 1;
+    this.nextBotId = 1;
+    this.pending = [];
+    this.complete = [];
+    this.bots = [];
+  }
+
+  addNormalOrder() {
+    return this.#addOrder(ORDER_TYPES.NORMAL);
+  }
+
+  addVipOrder() {
+    return this.#addOrder(ORDER_TYPES.VIP);
+  }
+
+  addBot() {
+    const bot = {
+      id: this.nextBotId++,
+      status: 'IDLE',
+      order: null,
+      timerId: null,
+    };
+    this.bots.push(bot);
+    this.#emit({ type: 'bot-created', botId: bot.id });
+    this.#assignNextOrder(bot);
+    return this.#publicBot(bot);
+  }
+
+  removeBot() {
+    const bot = this.bots.pop();
+    if (!bot) return null;
+
+    const removed = this.#publicBot(bot);
+    if (bot.status === 'PROCESSING' && bot.order) {
+      this.scheduler.clearTimeout(bot.timerId);
+      const interruptedOrder = bot.order;
+      interruptedOrder.status = 'PENDING';
+      this.pending.push(interruptedOrder);
+      this.#sortPending();
+      this.#emit({
+        type: 'order-requeued',
+        botId: bot.id,
+        orderId: interruptedOrder.id,
+        orderType: interruptedOrder.type,
+      });
+    }
+
+    this.#emit({ type: 'bot-removed', botId: bot.id });
+    this.#dispatchIdleBots();
+    return removed;
+  }
+
+  shutdown() {
+    for (const bot of this.bots) {
+      if (bot.timerId !== null) this.scheduler.clearTimeout(bot.timerId);
+      bot.timerId = null;
+    }
+  }
+
+  getSnapshot() {
+    return {
+      pending: this.pending.map((order) => this.#publicOrder(order)),
+      complete: this.complete.map((order) => this.#publicOrder(order)),
+      bots: this.bots.map((bot) => this.#publicBot(bot)),
+    };
+  }
+
+  #addOrder(type) {
+    const order = {
+      id: this.nextOrderId++,
+      type,
+      sequence: this.nextOrderId - 1,
+      status: 'PENDING',
+    };
+
+    this.pending.push(order);
+    this.#sortPending();
+    this.#emit({ type: 'order-created', orderId: order.id, orderType: order.type });
+    this.#dispatchIdleBots();
+    return this.#publicOrder(order);
+  }
+
+  #sortPending() {
+    this.pending.sort((left, right) => {
+      if (left.type !== right.type) return left.type === ORDER_TYPES.VIP ? -1 : 1;
+      return left.sequence - right.sequence;
+    });
+  }
+
+  #dispatchIdleBots() {
+    for (const bot of this.bots) {
+      if (this.pending.length === 0) break;
+      if (bot.status === 'IDLE') this.#assignNextOrder(bot);
+    }
+  }
+
+  #assignNextOrder(bot) {
+    if (bot.status !== 'IDLE') return;
+    const order = this.pending.shift();
+    if (!order) {
+      this.#emit({ type: 'bot-idle', botId: bot.id });
+      return;
+    }
+
+    order.status = 'PROCESSING';
+    bot.status = 'PROCESSING';
+    bot.order = order;
+    this.#emit({
+      type: 'order-started',
+      botId: bot.id,
+      orderId: order.id,
+      orderType: order.type,
+    });
+
+    bot.timerId = this.scheduler.setTimeout(
+      () => this.#completeOrder(bot.id, order.id),
+      this.processingMs,
+    );
+  }
+
+  #completeOrder(botId, orderId) {
+    const bot = this.bots.find((candidate) => candidate.id === botId);
+    if (!bot || bot.status !== 'PROCESSING' || bot.order?.id !== orderId) return;
+
+    const order = bot.order;
+    order.status = 'COMPLETE';
+    this.complete.push(order);
+    bot.status = 'IDLE';
+    bot.order = null;
+    bot.timerId = null;
+
+    this.#emit({
+      type: 'order-completed',
+      botId: bot.id,
+      orderId: order.id,
+      orderType: order.type,
+    });
+
+    if (this.pending.length > 0) this.#assignNextOrder(bot);
+    else this.#emit({ type: 'bot-idle', botId: bot.id });
+  }
+
+  #emit(event) {
+    this.onEvent(Object.freeze({ ...event }));
+  }
+
+  #publicOrder(order) {
+    return Object.freeze({ id: order.id, type: order.type, status: order.status });
+  }
+
+  #publicBot(bot) {
+    return Object.freeze({
+      id: bot.id,
+      status: bot.status,
+      orderId: bot.order?.id ?? null,
+    });
+  }
+}
+
+module.exports = { OrderController, ORDER_TYPES };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const cliPath = path.join(__dirname, '..', 'src', 'cli.js');
+
+test('interactive CLI accepts order and bot commands and timestamps every output line', () => {
+  const result = spawnSync(process.execPath, [cliPath], {
+    input: 'normal\nvip\nstatus\n+bot\n-bot\nexit\n',
+    encoding: 'utf8',
+    timeout: 2_000,
+  });
+
+  assert.equal(result.status, 0, `CLI failed:\n${result.stderr}`);
+  assert.match(result.stdout, /Order #1 NORMAL -> PENDING/);
+  assert.match(result.stdout, /Order #2 VIP -> PENDING/);
+  assert.match(result.stdout, /PENDING: \[VIP #2, NORMAL #1\]/);
+  assert.match(result.stdout, /Bot #1 created/);
+  assert.match(result.stdout, /Bot #1 started VIP order #2/);
+  assert.match(result.stdout, /Order #2 VIP -> PENDING \(Bot #1 removed\)/);
+  assert.match(result.stdout, /Bot #1 removed/);
+
+  const lines = result.stdout.split(/\r?\n/).filter(Boolean);
+  assert.ok(lines.length > 0);
+  for (const line of lines) {
+    assert.match(line, /^\d{2}:\d{2}:\d{2} /, `missing timestamp: ${line}`);
+  }
+});
+
+test('exit terminates promptly even while a bot is processing', () => {
+  const startedAt = Date.now();
+  const result = spawnSync(process.execPath, [cliPath], {
+    input: 'normal\n+bot\nexit\n',
+    encoding: 'utf8',
+    timeout: 1_000,
+  });
+  const elapsed = Date.now() - startedAt;
+
+  assert.equal(result.status, 0, `CLI did not exit cleanly: ${result.error?.message ?? result.stderr}`);
+  assert.ok(elapsed < 1_000, `CLI exit took ${elapsed}ms with an active bot`);
+});

--- a/test/order-controller.test.js
+++ b/test/order-controller.test.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { OrderController } = require('../src/order-controller');
+
+class ManualScheduler {
+  constructor() {
+    this.now = 0;
+    this.nextId = 1;
+    this.tasks = new Map();
+  }
+
+  setTimeout(callback, delayMs) {
+    const id = this.nextId++;
+    this.tasks.set(id, { at: this.now + delayMs, callback });
+    return id;
+  }
+
+  clearTimeout(id) {
+    this.tasks.delete(id);
+  }
+
+  advance(ms) {
+    const target = this.now + ms;
+    while (true) {
+      const due = [...this.tasks.entries()]
+        .filter(([, task]) => task.at <= target)
+        .sort((a, b) => a[1].at - b[1].at || a[0] - b[0])[0];
+      if (!due) break;
+      const [id, task] = due;
+      this.tasks.delete(id);
+      this.now = task.at;
+      task.callback();
+    }
+    this.now = target;
+  }
+}
+
+function createController(options = {}) {
+  const scheduler = options.scheduler ?? new ManualScheduler();
+  const events = [];
+  const controller = new OrderController({
+    scheduler,
+    processingMs: 10_000,
+    onEvent: (event) => events.push(event),
+  });
+  return { controller, scheduler, events };
+}
+
+function pendingIds(controller) {
+  return controller.getSnapshot().pending.map((order) => order.id);
+}
+
+test('normal and VIP orders keep VIP priority and FIFO while IDs increase uniquely', () => {
+  const { controller } = createController();
+
+  const normal1 = controller.addNormalOrder();
+  const normal2 = controller.addNormalOrder();
+  const vip3 = controller.addVipOrder();
+  const vip4 = controller.addVipOrder();
+
+  assert.deepEqual([normal1.id, normal2.id, vip3.id, vip4.id], [1, 2, 3, 4]);
+  assert.deepEqual(pendingIds(controller), [3, 4, 1, 2]);
+  assert.deepEqual(
+    controller.getSnapshot().pending.map((order) => order.type),
+    ['VIP', 'VIP', 'NORMAL', 'NORMAL'],
+  );
+});
+
+test('a new bot immediately picks an order and completes it only after 10 seconds', () => {
+  const { controller, scheduler } = createController();
+  controller.addNormalOrder();
+
+  const bot = controller.addBot();
+  let snapshot = controller.getSnapshot();
+  assert.equal(bot.id, 1);
+  assert.deepEqual(snapshot.pending, []);
+  assert.equal(snapshot.bots[0].status, 'PROCESSING');
+  assert.equal(snapshot.bots[0].orderId, 1);
+
+  scheduler.advance(9_999);
+  snapshot = controller.getSnapshot();
+  assert.deepEqual(snapshot.complete, []);
+  assert.equal(snapshot.bots[0].status, 'PROCESSING');
+
+  scheduler.advance(1);
+  snapshot = controller.getSnapshot();
+  assert.deepEqual(snapshot.complete.map((order) => order.id), [1]);
+  assert.equal(snapshot.bots[0].status, 'IDLE');
+  assert.equal(snapshot.bots[0].orderId, null);
+});
+
+test('an idle bot immediately picks a newly submitted order', () => {
+  const { controller } = createController();
+  controller.addBot();
+  assert.equal(controller.getSnapshot().bots[0].status, 'IDLE');
+
+  controller.addVipOrder();
+  const snapshot = controller.getSnapshot();
+  assert.deepEqual(snapshot.pending, []);
+  assert.equal(snapshot.bots[0].status, 'PROCESSING');
+  assert.equal(snapshot.bots[0].orderId, 1);
+});
+
+test('a bot automatically processes the next pending order after completion', () => {
+  const { controller, scheduler } = createController();
+  controller.addNormalOrder();
+  controller.addNormalOrder();
+  controller.addBot();
+
+  scheduler.advance(10_000);
+  let snapshot = controller.getSnapshot();
+  assert.deepEqual(snapshot.complete.map((order) => order.id), [1]);
+  assert.equal(snapshot.bots[0].orderId, 2);
+  assert.equal(snapshot.bots[0].status, 'PROCESSING');
+
+  scheduler.advance(10_000);
+  snapshot = controller.getSnapshot();
+  assert.deepEqual(snapshot.complete.map((order) => order.id), [1, 2]);
+  assert.equal(snapshot.bots[0].status, 'IDLE');
+});
+
+test('multiple bots process at most one order each in parallel', () => {
+  const { controller } = createController();
+  controller.addNormalOrder();
+  controller.addNormalOrder();
+  controller.addNormalOrder();
+
+  controller.addBot();
+  controller.addBot();
+
+  const snapshot = controller.getSnapshot();
+  assert.deepEqual(snapshot.bots.map((bot) => bot.orderId), [1, 2]);
+  assert.deepEqual(snapshot.pending.map((order) => order.id), [3]);
+  assert.equal(new Set(snapshot.bots.map((bot) => bot.orderId)).size, 2);
+});
+
+test('removing a processing bot cancels its timer and restores the order to original priority position', () => {
+  const { controller, scheduler } = createController();
+  controller.addVipOrder();
+  controller.addVipOrder();
+  controller.addNormalOrder();
+  controller.addBot();
+  controller.addNormalOrder();
+
+  const removed = controller.removeBot();
+  assert.equal(removed.id, 1);
+  assert.deepEqual(pendingIds(controller), [1, 2, 3, 4]);
+  assert.deepEqual(controller.getSnapshot().bots, []);
+
+  scheduler.advance(20_000);
+  const snapshot = controller.getSnapshot();
+  assert.deepEqual(snapshot.complete, []);
+  assert.deepEqual(snapshot.pending.map((order) => order.id), [1, 2, 3, 4]);
+});
+
+test('removing a bot always destroys the newest bot first', () => {
+  const { controller } = createController();
+  controller.addBot();
+  controller.addBot();
+  controller.addBot();
+
+  assert.equal(controller.removeBot().id, 3);
+  assert.deepEqual(controller.getSnapshot().bots.map((bot) => bot.id), [1, 2]);
+  assert.equal(controller.removeBot().id, 2);
+  assert.deepEqual(controller.getSnapshot().bots.map((bot) => bot.id), [1]);
+});
+
+test('removing a bot when none exist is a safe no-op', () => {
+  const { controller } = createController();
+  assert.equal(controller.removeBot(), null);
+  assert.deepEqual(controller.getSnapshot().bots, []);
+});


### PR DESCRIPTION
## Summary
- implement the in-memory Normal/VIP order controller in Node.js
- add cooking bot lifecycle with 10-second processing, IDLE behavior, parallel bots, and newest-bot removal
- restore interrupted orders to the correct VIP/Normal FIFO position
- add the required interactive CLI
- implement scripts/test.sh, scripts/build.sh, and scripts/run.sh
- generate meaningful timestamped output in scripts/result.txt

## Verification
- 9 unit tests covering priority, FIFO, increasing order numbers, bot processing, idle behavior, parallel bots, removal, and order restoration
- syntax/build checks for all CLI source files
- real 10-second demo exercised locally
- no runtime dependencies, persistence, database, or framework